### PR TITLE
Fix linting

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -40,7 +40,7 @@ This series of playbooks are mean to run based on the info inside the files on f
 Usually the name in the files are almost identical.
 To detect without error what files are linked to specific playbook, loom inside the same, there will be an import with the value:path to the file.
 ```
-   - include_vars: group_vars/consumer.yml
+   - ansible.builtin.include_vars: group_vars/consumer.yml
 ```
 
 ### sample_production/inventory.ini

--- a/ansible/sample_production/group_vars/consumer.yml
+++ b/ansible/sample_production/group_vars/consumer.yml
@@ -1,3 +1,4 @@
+---
 workdir: "keys"
 key_size: 2048
 

--- a/ansible/sample_production/group_vars/infrastructure.yml
+++ b/ansible/sample_production/group_vars/infrastructure.yml
@@ -1,3 +1,4 @@
+---
 regions:
   - name: region1
     display_name: region1

--- a/ansible/sample_production/group_vars/protection_policies.yml
+++ b/ansible/sample_production/group_vars/protection_policies.yml
@@ -1,5 +1,6 @@
+---
 protection_policy:
   - name: "pp_name_2"
     display_name: "pp_name_2"
-    local_rpo: "15" # in minutes, Minimum value is 10 minutes.
-    local_retention: "24h" # m(inutes), h(ours), d(ays), w(eeks), or y(ears).
+    local_rpo: "15"  # in minutes, Minimum value is 10 minutes.
+    local_retention: "24h"  # m(inutes), h(ours), d(ays), w(eeks), or y(ears).

--- a/ansible/sample_production/group_vars/storage_service_class.yml
+++ b/ansible/sample_production/group_vars/storage_service_class.yml
@@ -10,8 +10,8 @@ storage_class:
   - name: sc_name
     display_name: sc_name
     storage_service: ss_name
-    size_limit: 1T #100M 100G 100T 100P Default 4PB
-    iops_limit: 10000 #between 100 and 100000000
+    size_limit: 1T # 100M 100G 100T 100P Default 4PB
+    iops_limit: 10000 # between 100 and 100000000
     bw_limit: 4194M
 # - name: sc_name_1
 #   display_name: sc_name_1

--- a/ansible/sample_production/group_vars/storage_service_class.yml
+++ b/ansible/sample_production/group_vars/storage_service_class.yml
@@ -1,3 +1,4 @@
+---
 storage_service:
   - name: ss_name
     display_name: ss_name
@@ -10,8 +11,8 @@ storage_class:
   - name: sc_name
     display_name: sc_name
     storage_service: ss_name
-    size_limit: 1T # 100M 100G 100T 100P Default 4PB
-    iops_limit: 10000 # between 100 and 100000000
+    size_limit: 1T  # 100M 100G 100T 100P Default 4PB
+    iops_limit: 10000  # between 100 and 100000000
     bw_limit: 4194M
 # - name: sc_name_1
 #   display_name: sc_name_1

--- a/ansible/sample_production/group_vars/workloads.yml
+++ b/ansible/sample_production/group_vars/workloads.yml
@@ -4,7 +4,7 @@ tenant_space:
   - name: db_tenant_space
     display_name: oracle-db
     tenant: oracle_dbas
- 
+
 placement_groups:
   - name: pg1
     display_name: pg1
@@ -13,7 +13,7 @@ placement_groups:
     tenant_space: db_tenant_space
     region: region1
     availability_zone: az1
-    
+
 
 volumes:
   - name: data_vol1
@@ -52,4 +52,3 @@ volumes:
     placement_group: pg1
     host_access_policies: ["initiatorserver2"]
     mount_path: /mnt/config_vol
-

--- a/ansible/sample_production/group_vars/workloads.yml
+++ b/ansible/sample_production/group_vars/workloads.yml
@@ -1,3 +1,4 @@
+---
 prefix_disk: "3624a9370"
 
 tenant_space:

--- a/ansible/sample_production/list_consumer.yml
+++ b/ansible/sample_production/list_consumer.yml
@@ -2,46 +2,46 @@
 - hosts: localhost
 
   tasks:
-  - include_vars: group_vars/consumer.yml
-  - set_fact:
-      tenants_dict: {}
+    - ansible.builtin.include_vars: group_vars/consumer.yml
+    - ansible.builtin.set_fact:
+        tenants_dict: { }
 
-  - name: Get tenants
-    purestorage.fusion.fusion_info:
-      app_id: "{{ api_client }}"
-      key_file: "{{ priv_key_file }}"
-      gather_subset: tenants
-    register: fusion_info
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
-  
-  - name: Get tenant_spaces
-    purestorage.fusion.fusion_info:
-      app_id: "{{ api_client }}"
-      key_file: "{{ priv_key_file }}"
-      gather_subset: tenant_spaces
-    register: fusion_info
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Get tenants
+      purestorage.fusion.fusion_info:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        gather_subset: tenants
+      register: fusion_info
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
 
-  - name: Collect api_clients from Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: api_clients
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Get tenant_spaces
+      purestorage.fusion.fusion_info:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        gather_subset: tenant_spaces
+      register: fusion_info
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
 
-  - name: Collect Roles from Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: roles
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Collect api_clients from Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: api_clients
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
 
-  - name: Collect Users from Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: users
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Collect Roles from Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: roles
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+
+    - name: Collect Users from Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: users
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/sample_production/list_consumer.yml
+++ b/ansible/sample_production/list_consumer.yml
@@ -1,10 +1,13 @@
 ---
-- hosts: localhost
-
+- name: List consumer items
+  hosts: localhost
   tasks:
-    - ansible.builtin.include_vars: group_vars/consumer.yml
-    - ansible.builtin.set_fact:
-        tenants_dict: { }
+    - name: Import consumer variables
+      ansible.builtin.include_vars: group_vars/consumer.yml
+
+    - name: Setup local variables
+      ansible.builtin.set_fact:
+        tenants_dict: {}
 
     - name: Get tenants
       purestorage.fusion.fusion_info:
@@ -12,7 +15,10 @@
         key_file: "{{ priv_key_file }}"
         gather_subset: tenants
       register: fusion_info
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+
+    - name: Print tenants
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"
 
     - name: Get tenant_spaces
       purestorage.fusion.fusion_info:
@@ -20,7 +26,10 @@
         key_file: "{{ priv_key_file }}"
         gather_subset: tenant_spaces
       register: fusion_info
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+
+    - name: Print tenant spaces
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"
 
     - name: Collect api_clients from Pure Storage
       purestorage.fusion.fusion_info:
@@ -28,7 +37,10 @@
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+
+    - name: Print API clients
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"
 
     - name: Collect Roles from Pure Storage
       purestorage.fusion.fusion_info:
@@ -36,7 +48,10 @@
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+
+    - name: Print roles
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"
 
     - name: Collect Users from Pure Storage
       purestorage.fusion.fusion_info:
@@ -44,4 +59,7 @@
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+
+    - name: Print users spaces
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/sample_production/setup_consumer.yml
+++ b/ansible/sample_production/setup_consumer.yml
@@ -2,34 +2,34 @@
 - hosts: localhost
 
   tasks:
-    - include_vars: group_vars/consumer.yml
-    - set_fact:
-        tenants_dict: {}
+    - ansible.builtin.include_vars: group_vars/consumer.yml
+    - ansible.builtin.set_fact:
+        tenants_dict: { }
 
     - name: Check private key exists
-      stat:
-        path: "{{ ansible_env.PRIV_KEY_FILE}}"
+      ansible.builtin.stat:
+        path: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: result
 
     - name: End run if missing private key
-      meta: end_play
+      ansible.builtin.meta: end_play
       when: (result.stat.isreg is undefined) or (not result.stat.isreg)
 
-    - name: "Creates work directory {{workdir}}"
-      file:
-        path: "{{workdir}}"
+    - name: "Creates work directory {{ workdir }}"
+      ansible.builtin.file:
+        path: "{{ workdir }}"
         state: directory
 
     - name: "Creates tenants folders"
-      file:
-        path: "{{workdir}}/{{ item.name }}"
+      ansible.builtin.file:
+        path: "{{ workdir }}/{{ item.name }}"
         state: directory
       loop: "{{ tenants }}"
 
     - name: Create new tenant(s)
       purestorage.fusion.fusion_tenant:
-        app_id: "{{ ansible_env.API_CLIENT}}"
-        key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
         state: present # or absent
         name: "{{ item.name }}"
         display_name: "{{ item.display_name }}"
@@ -37,55 +37,54 @@
 
     - name: Create a Private RSA key
       community.crypto.openssl_privatekey:
-        path: "{{workdir}}/{{item.name}}/priv_{{item.name}}.pem"
+        path: "{{ workdir }}/{{ item.name }}/priv_{{ item.name }}.pem"
         type: RSA
-        size: "{{key_size}}"
+        size: "{{ key_size }}"
       loop: "{{ tenants }}"
 
     - name: Create a Public RSA key
       community.crypto.openssl_publickey:
-        path: "{{workdir}}/{{item.name}}/pub_{{item.name}}.pem"
-        privatekey_path: "{{workdir}}/{{item.name}}/priv_{{item.name}}.pem"
+        path: "{{ workdir }}/{{ item.name }}/pub_{{ item.name }}.pem"
+        privatekey_path: "{{ workdir }}/{{ item.name }}/priv_{{ item.name }}.pem"
       loop: "{{ tenants }}"
 
     - name: Create new API client foo
       purestorage.fusion.fusion_api_client:
-        app_id: "{{ ansible_env.API_CLIENT}}"
-        key_file: "{{ ansible_env.PRIV_KEY_FILE}}"  
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
         state: present
         name: "{{ item.name }}"
-        public_key: "{{lookup('file', workdir + '/' + item.name + '/pub_' + item.name + '.pem') }}"
+        public_key: "{{ lookup('file', workdir + '/' + item.name + '/pub_' + item.name + '.pem') }}"
       loop: "{{ tenants }}"
 
     - name: Convert Tenant list to dict
-      set_fact:
-        tenants_dict: "{{ tenants_dict|combine( {item.name: item.display_name} ) }}"
+      ansible.builtin.set_fact:
+        tenants_dict: "{{ tenants_dict | combine({item.name: item.display_name}) }}"
       with_items:
-          - "{{ tenants }}"
+        - "{{ tenants }}"
 
-    - name: Collect Api Clients 
+    - name: Collect Api Clients
       purestorage.fusion.fusion_info:
         gather_subset: api_clients
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - name: Creating a file .iss in tenant folder 
-      copy:
-        dest: "{{workdir}}/{{item.value.display_name}}/{{item.value.display_name}}.iss"
+    - name: Creating a file .iss in tenant folder
+      ansible.builtin.copy:
+        dest: "{{ workdir }}/{{ item.value.display_name }}/{{ item.value.display_name }}.iss"
         content: "{{ item.value.issuer }}"
       with_dict: "{{ fusion_info['fusion_info']['api_clients'] }}"
       when: item.value.display_name in tenants_dict.keys()
-    
+
     - name: Role Assignment to Tenant(s)
       purestorage.fusion.fusion_ra:
-        app_id: "{{ ansible_env.API_CLIENT}}"
-        key_file: "{{ ansible_env.PRIV_KEY_FILE}}"  
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
         state: present
-        name: "tenant-admin" 
+        name: "tenant-admin"
         scope: "tenant"  # "organization" "tenant_space"
         tenant: "{{ item.value.display_name }}"
-        user: "{{item.value.issuer}}"
+        user: "{{ item.value.issuer }}"
       with_dict: "{{ fusion_info['fusion_info']['api_clients'] }}"
       when: item.value.display_name in tenants_dict.keys()
-      

--- a/ansible/sample_production/setup_consumer.yml
+++ b/ansible/sample_production/setup_consumer.yml
@@ -1,10 +1,13 @@
 ---
-- hosts: localhost
-
+- name: Setup consumer
+  hosts: localhost
   tasks:
-    - ansible.builtin.include_vars: group_vars/consumer.yml
-    - ansible.builtin.set_fact:
-        tenants_dict: { }
+    - name: Import consumer variables
+      ansible.builtin.include_vars: group_vars/consumer.yml
+
+    - name: Setup local variables
+      ansible.builtin.set_fact:
+        tenants_dict: {}
 
     - name: Check private key exists
       ansible.builtin.stat:
@@ -19,11 +22,13 @@
       ansible.builtin.file:
         path: "{{ workdir }}"
         state: directory
+        mode: 0755
 
     - name: "Creates tenants folders"
       ansible.builtin.file:
         path: "{{ workdir }}/{{ item.name }}"
         state: directory
+        mode: 0755
       loop: "{{ tenants }}"
 
     - name: Create new tenant(s)
@@ -74,6 +79,7 @@
       ansible.builtin.copy:
         dest: "{{ workdir }}/{{ item.value.display_name }}/{{ item.value.display_name }}.iss"
         content: "{{ item.value.issuer }}"
+        mode: 0644
       with_dict: "{{ fusion_info['fusion_info']['api_clients'] }}"
       when: item.value.display_name in tenants_dict.keys()
 

--- a/ansible/sample_production/setup_infrastructure.yml
+++ b/ansible/sample_production/setup_infrastructure.yml
@@ -1,74 +1,75 @@
 ---
 - hosts: localhost
   tasks:
-  - include_vars: group_vars/infrastructure.yml
+    - ansible.builtin.include_vars: group_vars/infrastructure.yml
 
-  - name: Check private key exists
-    stat:
-      path: "{{ priv_key_file }}"
-    register: result
+    - name: Check private key exists
+      ansible.builtin.stat:
+        path: "{{ priv_key_file }}"
+      register: result
 
-  - name: End run if missing private key
-    meta: end_play
-    when: (result.stat.isreg is undefined) or (not result.stat.isreg)
+    - name: End run if missing private key
+      ansible.builtin.meta: end_play
+      when: (result.stat.isreg is undefined) or (not result.stat.isreg)
 
-  - name: Create new region(s)
-    purestorage.fusion.fusion_region:
-      app_id: "{{ api_client }}"
-      key_file: "{{ priv_key_file }}"
-      state: present # or absent
-      name: "{{ item.name }}"
-      display_name: "{{ item.display_name }}"
-    loop: "{{ regions }}"
+    - name: Create new region(s)
+      purestorage.fusion.fusion_region:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        state: present # or absent
+        name: "{{ item.name }}"
+        display_name: "{{ item.display_name }}"
+      loop: "{{ regions }}"
 
-  - name: Create new Availability Zone(s)
-    purestorage.fusion.fusion_az:
-      app_id: "{{ api_client }}"
-      key_file: "{{ priv_key_file }}"
-      state: present # or absent
-      name: "{{ item.name }}"
-      display_name: "{{ item.display_name }}"
-    loop: "{{ availability_zones }}"
+    - name: Create new Availability Zone(s)
+      purestorage.fusion.fusion_az:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        state: present # or absent
+        name: "{{ item.name }}"
+        display_name: "{{ item.display_name }}"
+      loop: "{{ availability_zones }}"
 
-  - name: Create new network interface group(s)
-    purestorage.fusion.fusion_nig:
-      app_id: "{{ api_client }}"
-      key_file: "{{ priv_key_file }}"
-      state: present # or absent
-      name: "{{ item.name }}"
-      display_name: "{{ item.display_name }}"
-      availability_zone: "{{ item.availability_zone }}"
-      region: "{{ item.region }}"
-      group_type: "{{ item.group_type }}"
-      mtu: "{{ item.mtu }}"
-      gateway: "{{ item.gateway }}"
-      prefix: "{{ item.prefix }}"
-    loop: "{{ network_interface_groups }}"
+    - name: Create new network interface group(s)
+      purestorage.fusion.fusion_nig:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        state: present # or absent
+        name: "{{ item.name }}"
+        display_name: "{{ item.display_name }}"
+        availability_zone: "{{ item.availability_zone }}"
+        region: "{{ item.region }}"
+        group_type: "{{ item.group_type }}"
+        mtu: "{{ item.mtu }}"
+        gateway: "{{ item.gateway }}"
+        prefix: "{{ item.prefix }}"
+      loop: "{{ network_interface_groups }}"
 
-  - name: Create new Storage Endpoint network(s)
-    purestorage.fusion.fusion_se:
-      app_id: "{{ api_client }}"
-      key_file: "{{ priv_key_file }}"
-      state: present # or absent
-      name: "{{ item.name }}"
-      display_name: "{{ item.display_name }}"
-      availability_zone: "{{ item.availability_zone }}"
-      gateway: "{{ item.gateway }}"
-      addresses: "{{ item.address }}"
-      network_interface_groups: "{{ item.network_interface_groups }}"
-      endpoint_type: "{{item.endpoint_type}}"
-    loop: "{{ storage_endpoints }}"
+    - name: Create new Storage Endpoint network(s)
+      purestorage.fusion.fusion_se:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        state: present # or absent
+        name: "{{ item.name }}"
+        display_name: "{{ item.display_name }}"
+        availability_zone: "{{ item.availability_zone }}"
+        gateway: "{{ item.gateway }}"
+        addresses: "{{ item.address }}"
+        network_interface_groups: "{{ item.network_interface_groups }}"
+        endpoint_type: "{{ item.endpoint_type }}"
+        region: "{{ item.region }}"
+      loop: "{{ storage_endpoints }}"
 
-  - name: Create new array(s)
-    purestorage.fusion.fusion_array:
-      app_id: "{{ api_client }}"
-      key_file: "{{ priv_key_file }}"
-      state: present # or absent
-      name: "{{ item.name }}"
-      display_name: "{{ item.display_name }}"
-      appliance_id: "{{ item.appliance_id }}"
-      host_name: "{{ item.host_name }}"
-      az: "{{ item.az }}"
-      hardware_type: "{{ item.hardware_type }}"
-      region: "{{ item.region }}"
-    loop: "{{ arrays }}"
+    - name: Create new array(s)
+      purestorage.fusion.fusion_array:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        state: present # or absent
+        name: "{{ item.name }}"
+        display_name: "{{ item.display_name }}"
+        appliance_id: "{{ item.appliance_id }}"
+        host_name: "{{ item.host_name }}"
+        az: "{{ item.az }}"
+        hardware_type: "{{ item.hardware_type }}"
+        region: "{{ item.region }}"
+      loop: "{{ arrays }}"

--- a/ansible/sample_production/setup_infrastructure.yml
+++ b/ansible/sample_production/setup_infrastructure.yml
@@ -1,7 +1,9 @@
 ---
-- hosts: localhost
+- name: Setup infrastructure
+  hosts: localhost
   tasks:
-    - ansible.builtin.include_vars: group_vars/infrastructure.yml
+    - name: Import infrastructure variables
+      ansible.builtin.include_vars: group_vars/infrastructure.yml
 
     - name: Check private key exists
       ansible.builtin.stat:

--- a/ansible/sample_production/setup_protection_policies.yml
+++ b/ansible/sample_production/setup_protection_policies.yml
@@ -4,24 +4,24 @@
   # wiki: https://docs.ansible.com/ansible/latest/collections/purestorage/fusion/fusion_pp_module.html#ansible-collections-purestorage-fusion-fusion-pp-module
 
   tasks:
-  - include_vars: group_vars/protection_policies.yml
+    - ansible.builtin.include_vars: group_vars/protection_policies.yml
 
-  - name: Check private key exists
-    stat:
-      path: "{{ priv_key_file }}"
-    register: result
+    - name: Check private key exists
+      ansible.builtin.stat:
+        path: "{{ priv_key_file }}"
+      register: result
 
-  - name: End run if missing private key
-    meta: end_play
-    when: (result.stat.isreg is undefined) or (not result.stat.isreg)
+    - name: End run if missing private key
+      ansible.builtin.meta: end_play
+      when: (result.stat.isreg is undefined) or (not result.stat.isreg)
 
-  - name: Create new protection policy(s)
-    purestorage.fusion.fusion_pp:
-      app_id: "{{ api_client }}"
-      key_file: "{{ priv_key_file }}"
-      state: present # or absent
-      name: "{{ item.name }}"
-      display_name: "{{ item.display_name }}"
-      local_rpo: "{{ item.local_rpo }}"
-      local_retention: "{{ item.local_retention }}"
-    loop: "{{ protection_policy }}"
+    - name: Create new protection policy(s)
+      purestorage.fusion.fusion_pp:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        state: present # or absent
+        name: "{{ item.name }}"
+        display_name: "{{ item.display_name }}"
+        local_rpo: "{{ item.local_rpo }}"
+        local_retention: "{{ item.local_retention }}"
+      loop: "{{ protection_policy }}"

--- a/ansible/sample_production/setup_protection_policies.yml
+++ b/ansible/sample_production/setup_protection_policies.yml
@@ -1,10 +1,12 @@
 ---
-- hosts: localhost
-  # this playbook create a new protection policy
+- name: Setup protection policy
+  hosts: localhost
+  # this playbook creates a new protection policy
   # wiki: https://docs.ansible.com/ansible/latest/collections/purestorage/fusion/fusion_pp_module.html#ansible-collections-purestorage-fusion-fusion-pp-module
 
   tasks:
-    - ansible.builtin.include_vars: group_vars/protection_policies.yml
+    - name: Import protection policy variables
+      ansible.builtin.include_vars: group_vars/protection_policies.yml
 
     - name: Check private key exists
       ansible.builtin.stat:

--- a/ansible/sample_production/setup_storage_service_class.yml
+++ b/ansible/sample_production/setup_storage_service_class.yml
@@ -5,38 +5,36 @@
   # wiki: https://docs.ansible.com/ansible/latest/collections/purestorage/fusion/fusion_sc_module.html#ansible-collections-purestorage-fusion-fusion-sc-module
 
   tasks:
-  - include_vars: group_vars/storage_service_class.yml
+    - ansible.builtin.include_vars: group_vars/storage_service_class.yml
 
-  - name: Check private key exists
-    stat:
-      path: "{{ priv_key_file }}"
-    register: result
+    - name: Check private key exists
+      ansible.builtin.stat:
+        path: "{{ priv_key_file }}"
+      register: result
 
-  - name: End run if missing private key
-    meta: end_play
-    when: (result.stat.isreg is undefined) or (not result.stat.isreg)
+    - name: End run if missing private key
+      ansible.builtin.meta: end_play
+      when: (result.stat.isreg is undefined) or (not result.stat.isreg)
 
-  - name:  Create new storage service
-    purestorage.fusion.fusion_ss:
-      # wiki: https://docs.ansible.com/ansible/latest/collections/purestorage/fusion/fusion_ss_module.html#ansible-collections-purestorage-fusion-fusion-ss-module
-      app_id: "{{ api_client }}"
-      key_file: "{{ priv_key_file }}"
-      state: present # or absent
-      name: "{{ item.name }}"
-      display_name: "{{ item.display_name }}"
-      hardware_types: "{{ item.hardware_types }}"
-    loop: "{{ storage_service }}"
+    - name: Create new storage service
+      purestorage.fusion.fusion_ss:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        state: present # or absent
+        name: "{{ item.name }}"
+        display_name: "{{ item.display_name }}"
+        hardware_types: "{{ item.hardware_types }}"
+      loop: "{{ storage_service }}"
 
-  - name: Create new storage class
-    purestorage.fusion.fusion_sc:
-      #wiki: https://docs.ansible.com/ansible/latest/collections/purestorage/fusion/fusion_sc_module.html#ansible-collections-purestorage-fusion-fusion-sc-module
-      app_id: "{{ api_client }}"
-      key_file: "{{ priv_key_file }}"
-      state: present # or absent
-      name: "{{ item.name }}"
-      display_name: "{{ item.display_name }}"
-      storage_service: "{{ item.storage_service }}"
-      size_limit: "{{ item.size_limit }}"
-      iops_limit: {{ item.iops_limit }}
-      bw_limit: "{{ item.bw_limit }}"
-    loop: "{{ storage_class }}"
+    - name: Create new storage class
+      purestorage.fusion.fusion_sc:
+        app_id: "{{ api_client }}"
+        key_file: "{{ priv_key_file }}"
+        state: present # or absent
+        name: "{{ item.name }}"
+        display_name: "{{ item.display_name }}"
+        storage_service: "{{ item.storage_service }}"
+        size_limit: "{{ item.size_limit }}"
+        iops_limit: "{{ item.iops_limit }}"
+        bw_limit: "{{ item.bw_limit }}"
+      loop: "{{ storage_class }}"

--- a/ansible/sample_production/setup_storage_service_class.yml
+++ b/ansible/sample_production/setup_storage_service_class.yml
@@ -1,11 +1,13 @@
 ---
-- hosts: localhost
+- name: Setup storage service & class
+  hosts: localhost
   # this playbook create a new storage service and class
   # wiki: https://docs.ansible.com/ansible/latest/collections/purestorage/fusion/fusion_ss_module.html#ansible-collections-purestorage-fusion-fusion-ss-module
   # wiki: https://docs.ansible.com/ansible/latest/collections/purestorage/fusion/fusion_sc_module.html#ansible-collections-purestorage-fusion-fusion-sc-module
 
   tasks:
-    - ansible.builtin.include_vars: group_vars/storage_service_class.yml
+    - name: Import storage service/class variables
+      ansible.builtin.include_vars: group_vars/storage_service_class.yml
 
     - name: Check private key exists
       ansible.builtin.stat:

--- a/ansible/sample_production/setup_workloads.yml
+++ b/ansible/sample_production/setup_workloads.yml
@@ -2,39 +2,39 @@
 - hosts: Initiators_Hosts
 
   become: true
-  tasks: 
+  tasks:
 
     - name: Obtain IQN from Initiators_Hosts
-      shell: cat /etc/iscsi/initiatorname.iscsi | grep "^InitiatorName=iqn" | awk -F'=' '{print $2}'
+      ansible.builtin.shell: cat /etc/iscsi/initiatorname.iscsi | grep "^InitiatorName=iqn" | awk -F'=' '{print $2}'
       register: iqn
 
     - name: IQN Results
-      debug:
-        msg: 
-        - "Inventory Hostname: {{inventory_hostname}}"
-        - "Hostname: {{ansible_hostname}}"
-        - "IQN: {{iqn.stdout}}"
-   
+      ansible.builtin.debug:
+        msg:
+          - "Inventory Hostname: {{ inventory_hostname }}"
+          - "Hostname: {{ ansible_hostname }}"
+          - "IQN: {{ iqn.stdout }}"
+
 - hosts: localhost
 
   tasks:
-    - include_vars: group_vars/workloads.yml
-    
-    - set_fact:
+    - ansible.builtin.include_vars: group_vars/workloads.yml
+
+    - ansible.builtin.set_fact:
         iqn_data: []
-        map_volumes: {}
+        map_volumes: { }
 
     - name: Check private key exists
-      stat:
+      ansible.builtin.stat:
         path: "{{ priv_key_file }}"
       register: result
 
     - name: End run if missing private key
-      meta: end_play
+      ansible.builtin.meta: end_play
       when: (result.stat.isreg is undefined) or (not result.stat.isreg)
 
     - name: Create IQN/Hostname dictionary
-      set_fact: 
+      ansible.builtin.set_fact:
         iqn_data: "{{ iqn_data|default({}) + [ {'hostname':item, 'iqn':(hostvars[item]['iqn'].stdout)} ] }}"
       with_items:
         - "{{ groups['Initiators_Hosts'] }}"
@@ -48,7 +48,7 @@
         display_name: "{{ item.hostname }}"
         personality: "linux"
         iqn: "{{ item.iqn }}"
-      with_items: "{{iqn_data}}"
+      with_items: "{{ iqn_data }}"
       when: item.iqn != ""
 
     - name: Create new tenant space(s)
@@ -71,6 +71,7 @@
         tenant: "{{ item.tenant }}"
         tenant_space: "{{ item.tenant_space }}"
         availability_zone: "{{ item.availability_zone }}"
+        storage_service: "{{ item.storage_service }}"
         region: "{{ item.region }}"
       loop: "{{ placement_groups }}"
 
@@ -86,9 +87,9 @@
         tenant: "{{ item.tenant }}"
         tenant_space: "{{ item.tenant_space }}"
         placement_group: "{{ item.placement_group }}"
-        hosts: "{{ item.host_access_policies }}"
+        host_access_policies: "{{ item.host_access_policies }}"
       loop: "{{ volumes }}"
-    
+
     - name: Get Volumes info
       purestorage.fusion.fusion_info:
         app_id: "{{ api_client }}"
@@ -97,11 +98,11 @@
       register: fusion_info
 
     - name: Map Volumes with (Serial ID and IQN )
-      set_fact:
+      ansible.builtin.set_fact:
         map_volumes: >-
-              {{ map_volumes|combine(
-              { item.value.name.lower() : { 'serial':(prefix_disk + item.value.serial_number).lower(), 'iqn':(item.value.target.iscsi.iqn).lower()} }
-              ) }}
+          {{ map_volumes|combine(
+          { item.value.name.lower() : { 'serial':(prefix_disk + item.value.serial_number).lower(), 'iqn':(item.value.target.iscsi.iqn).lower()} }
+          ) }}
       with_dict: "{{ fusion_info['fusion_info']['volumes'] }}"
 
     - name: Get Purestorage Storage Endpoints
@@ -113,42 +114,42 @@
 
 - hosts: Initiators_Hosts
   become: true
-  tasks: 
-    - set_fact:
-        valid_volumes: {}
-        devices: {}
+  tasks:
+    - ansible.builtin.set_fact:
+        valid_volumes: { }
+        devices: { }
         iscsi_interfaces: []
         list_ip: []
         iqn_list: []
         reg_fusion_info: "{{ hostvars['localhost']['reg_fusion_info'] }}"
 
     - name: Obtain list of volumes to mount
-      set_fact:
+      ansible.builtin.set_fact:
         valid_volumes: "{{ valid_volumes|combine( {item.name: item.mount_path} ) }}"
-      with_items: "{{ hostvars['localhost']['volumes'] }}" 
+      with_items: "{{ hostvars['localhost']['volumes'] }}"
       when: inventory_hostname in item.host_access_policies
 
-    - debug: msg="{{ valid_volumes }}" 
+    - ansible.builtin.debug: msg="{{ valid_volumes }}"
 
     - name: Parse volume, mount path and volume id
-      set_fact:
+      ansible.builtin.set_fact:
         devices: "{{ devices|combine( { valid_volumes[item.key]:item.value } ) }}"
       with_dict: "{{ hostvars['localhost']['map_volumes'] }}"
       when: item.key in valid_volumes.keys()
 
-    - debug:
-       msg:
-        - "Mount: /dev/mapper/{{ item.value.serial }}"
-        - "On: {{ item.key }}"
+    - ansible.builtin.debug:
+        msg:
+          - "Mount: /dev/mapper/{{ item.value.serial }}"
+          - "On: {{ item.key }}"
       with_dict: "{{ devices }}"
 
     - name: Get a list of iscsi_interfaces
-      set_fact:
+      ansible.builtin.set_fact:
         iscsi_interfaces: "{{ iscsi_interfaces + [reg_fusion_info['fusion_info']['storage_endpoints'][item]['iscsi_interfaces']] }}"
       with_items: "{{ reg_fusion_info['fusion_info']['storage_endpoints'].keys() }}"
 
     - name: Extract IP from iscsi_interfaces
-      set_fact:
+      ansible.builtin.set_fact:
         list_ip: "{{ list_ip + [item['address'].split('/')[0]] }}"
       with_items: "{{ iscsi_interfaces }}"
 
@@ -160,7 +161,7 @@
       with_items: "{{ list_ip }}"
 
     - name: Get a list of IQN with unique elements
-      set_fact:
+      ansible.builtin.set_fact:
         iqn_list: "{{ iqn_list + [ item.value.iqn ] }}"
       with_dict: "{{ devices }}"
       when: item.value.iqn not in iqn_list
@@ -168,7 +169,7 @@
     - name: Connect to the named target
       community.general.open_iscsi:
         login: true
-        target: "{{item}}"
+        target: "{{ item }}"
       loop: "{{ iqn_list }}"
 
     - name: Create a primary partition
@@ -181,19 +182,19 @@
     - name: Create/check ext4 partition
       community.general.filesystem:
         fstype: ext4
-        dev: "/dev/mapper/{{item.value.serial}}-part1"
+        dev: "/dev/mapper/{{ item.value.serial }}-part1"
       with_dict: "{{ devices }}"
 
     - name: Creates directory for mountpoints
-      file:
-        path: "{{item.key}}"
+      ansible.builtin.file:
+        path: "{{ item.key }}"
         state: directory
       with_dict: "{{ devices }}"
 
     - name: Mount volumes
       ansible.posix.mount:
-        path: "{{item.key}}"
-        src: "/dev/mapper/{{item.value.serial}}-part1"
+        path: "{{ item.key }}"
+        src: "/dev/mapper/{{ item.value.serial }}-part1"
         fstype: ext4
         state: mounted
       with_dict: "{{ devices }}"
@@ -209,9 +210,9 @@
         dest: "/tmp/initiator_random_write.fio"
 
     - name: Run FIO process
-      command: "chdir={{item.mount_path}} fio /tmp/initiator_random_write.fio"
+      ansible.builtin.command: "chdir={{ item.mount_path }} fio /tmp/initiator_random_write.fio"
       with_items: "{{ hostvars['localhost']['volumes'] }}"
       register: ps
-      
+
     - name: FIO Results
-      debug: var=ps.stdout_lines
+      ansible.builtin.debug: var=ps.stdout_lines

--- a/ansible/sample_production/setup_workloads.yml
+++ b/ansible/sample_production/setup_workloads.yml
@@ -1,12 +1,16 @@
 ---
-- hosts: Initiators_Hosts
-
+- name: List IQN
+  hosts: Initiators_Hosts
   become: true
   tasks:
-
     - name: Obtain IQN from Initiators_Hosts
-      ansible.builtin.shell: cat /etc/iscsi/initiatorname.iscsi | grep "^InitiatorName=iqn" | awk -F'=' '{print $2}'
+      ansible.builtin.shell: >
+        set -o pipefail &&
+        (cat /etc/iscsi/initiatorname.iscsi |
+        grep "^InitiatorName=iqn" |
+        awk -F'=' '{print $2}')
       register: iqn
+      changed_when: false
 
     - name: IQN Results
       ansible.builtin.debug:
@@ -15,14 +19,16 @@
           - "Hostname: {{ ansible_hostname }}"
           - "IQN: {{ iqn.stdout }}"
 
-- hosts: localhost
-
+- name: Setup environment
+  hosts: localhost
   tasks:
-    - ansible.builtin.include_vars: group_vars/workloads.yml
+    - name: Import storage service/class variables
+      ansible.builtin.include_vars: group_vars/workloads.yml
 
-    - ansible.builtin.set_fact:
+    - name: Setup local variables
+      ansible.builtin.set_fact:
         iqn_data: []
-        map_volumes: { }
+        map_volumes: {}
 
     - name: Check private key exists
       ansible.builtin.stat:
@@ -49,7 +55,7 @@
         personality: "linux"
         iqn: "{{ item.iqn }}"
       with_items: "{{ iqn_data }}"
-      when: item.iqn != ""
+      when: item.iqn|length > 0
 
     - name: Create new tenant space(s)
       purestorage.fusion.fusion_ts:
@@ -112,12 +118,14 @@
         key_file: "{{ priv_key_file }}"
       register: reg_fusion_info
 
-- hosts: Initiators_Hosts
+- name: Run an IO workload
+  hosts: Initiators_Hosts
   become: true
   tasks:
-    - ansible.builtin.set_fact:
-        valid_volumes: { }
-        devices: { }
+    - name: Setup local variables
+      ansible.builtin.set_fact:
+        valid_volumes: {}
+        devices: {}
         iscsi_interfaces: []
         list_ip: []
         iqn_list: []
@@ -129,7 +137,9 @@
       with_items: "{{ hostvars['localhost']['volumes'] }}"
       when: inventory_hostname in item.host_access_policies
 
-    - ansible.builtin.debug: msg="{{ valid_volumes }}"
+    - name: Print valid volumes
+      ansible.builtin.debug:
+        msg: "{{ valid_volumes }}"
 
     - name: Parse volume, mount path and volume id
       ansible.builtin.set_fact:
@@ -137,7 +147,8 @@
       with_dict: "{{ hostvars['localhost']['map_volumes'] }}"
       when: item.key in valid_volumes.keys()
 
-    - ansible.builtin.debug:
+    - name: Print mount pairs
+      ansible.builtin.debug:
         msg:
           - "Mount: /dev/mapper/{{ item.value.serial }}"
           - "On: {{ item.key }}"
@@ -189,6 +200,7 @@
       ansible.builtin.file:
         path: "{{ item.key }}"
         state: directory
+        mode: 0755
       with_dict: "{{ devices }}"
 
     - name: Mount volumes
@@ -208,11 +220,16 @@
       ansible.builtin.copy:
         src: "./files/initiator_random_write.fio"
         dest: "/tmp/initiator_random_write.fio"
+        mode: 0644
 
     - name: Run FIO process
-      ansible.builtin.command: "chdir={{ item.mount_path }} fio /tmp/initiator_random_write.fio"
+      ansible.builtin.command:
+        chdir: "{{ item.mount_path }}"
+        cmd: "fio /tmp/initiator_random_write.fio"
       with_items: "{{ hostvars['localhost']['volumes'] }}"
       register: ps
+      changed_when: true
 
     - name: FIO Results
-      ansible.builtin.debug: var=ps.stdout_lines
+      ansible.builtin.debug:
+        var: "ps.stdout_lines"

--- a/ansible/sample_production/teardown_consumer.yml
+++ b/ansible/sample_production/teardown_consumer.yml
@@ -2,55 +2,54 @@
 - hosts: localhost
 
   tasks:
-    - include_vars: group_vars/consumer.yml
-    - set_fact:
-        tenants_dict: {}
+    - ansible.builtin.include_vars: group_vars/consumer.yml
+    - ansible.builtin.set_fact:
+        tenants_dict: { }
 
     - name: Convert Tenant list to dict
-      set_fact:
-        tenants_dict: "{{ tenants_dict|combine( {item.name: item.display_name} ) }}"
+      ansible.builtin.set_fact:
+        tenants_dict: "{{ tenants_dict | combine({item.name: item.display_name}) }}"
       with_items:
-          - "{{ tenants }}"
+        - "{{ tenants }}"
 
-    - name: Collect Api Clients 
+    - name: Collect Api Clients
       purestorage.fusion.fusion_info:
         gather_subset: api_clients
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
-      
+
     - name: Delete Role Assignment to Tenant(s)
       purestorage.fusion.fusion_ra:
-        app_id: "{{ ansible_env.API_CLIENT}}"
-        key_file: "{{ ansible_env.PRIV_KEY_FILE}}"  
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
         state: absent
-        name: "tenant-admin" 
+        name: "tenant-admin"
         scope: "tenant"  # "organization" "tenant_space"
         tenant: "{{ item.value.display_name }}"
-        user: "{{item.value.issuer}}"
+        user: "{{ item.value.issuer }}"
       with_dict: "{{ fusion_info['fusion_info']['api_clients'] }}"
       when: item.value.display_name in tenants_dict.keys()
 
-    - name: Delete API clients 
+    - name: Delete API clients
       purestorage.fusion.fusion_api_client:
-        app_id: "{{ ansible_env.API_CLIENT}}"
-        key_file: "{{ ansible_env.PRIV_KEY_FILE}}"  
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
         state: absent
         name: "{{ item.name }}"
-        public_key: "{{lookup('file', workdir + '/' + item.name + '/pub_' + item.name + '.pem') }}"
+        public_key: "{{ lookup('file', workdir + '/' + item.name + '/pub_' + item.name + '.pem') }}"
       loop: "{{ tenants }}"
 
     - name: Delete Tenants
       purestorage.fusion.fusion_tenant:
-        app_id: "{{ ansible_env.API_CLIENT}}"
-        key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
         state: absent
         name: "{{ item.name }}"
       loop: "{{ tenants }}"
 
     - name: Delete Tenants directory
-      file:
+      ansible.builtin.file:
         state: absent
-        path: "{{workdir}}/{{item.name}}"
+        path: "{{ workdir }}/{{ item.name }}"
       loop: "{{ tenants }}"
-

--- a/ansible/sample_production/teardown_consumer.yml
+++ b/ansible/sample_production/teardown_consumer.yml
@@ -1,10 +1,13 @@
 ---
-- hosts: localhost
-
+- name: Teardown consumer
+  hosts: localhost
   tasks:
-    - ansible.builtin.include_vars: group_vars/consumer.yml
-    - ansible.builtin.set_fact:
-        tenants_dict: { }
+    - name: Import consumer variables
+      ansible.builtin.include_vars: group_vars/consumer.yml
+
+    - name: Setup local variables
+      ansible.builtin.set_fact:
+        tenants_dict: {}
 
     - name: Convert Tenant list to dict
       ansible.builtin.set_fact:
@@ -37,7 +40,14 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
         state: absent
         name: "{{ item.name }}"
-        public_key: "{{ lookup('file', workdir + '/' + item.name + '/pub_' + item.name + '.pem') }}"
+        public_key: "{{
+          lookup('file',
+          workdir +
+          '/' +
+          item.name +
+          '/pub_' +
+          item.name +
+          '.pem') }}"
       loop: "{{ tenants }}"
 
     - name: Delete Tenants

--- a/ansible/sample_production/teardown_workloads.yml
+++ b/ansible/sample_production/teardown_workloads.yml
@@ -2,18 +2,18 @@
 - hosts: localhost
 
   tasks:
-    - include_vars: group_vars/workloads.yml
-    
-    - set_fact:
-        map_volumes: {}
+    - ansible.builtin.include_vars: group_vars/workloads.yml
+
+    - ansible.builtin.set_fact:
+        map_volumes: { }
 
     - name: Check private key exists
-      stat:
+      ansible.builtin.stat:
         path: "{{ priv_key_file }}"
       register: result
 
     - name: End run if missing private key
-      meta: end_play
+      ansible.builtin.meta: end_play
       when: (result.stat.isreg is undefined) or (not result.stat.isreg)
 
     - name: Get Volumes info
@@ -24,11 +24,11 @@
       register: fusion_info
 
     - name: Map Volumes with (Serial ID and IQN )
-      set_fact:
+      ansible.builtin.set_fact:
         map_volumes: >-
-              {{ map_volumes|combine(
-              { item.value.name.lower() : { 'serial':(prefix_disk + item.value.serial_number).lower(), 'iqn':(item.value.target.iscsi.iqn).lower()} }
-              ) }}
+          {{ map_volumes|combine(
+          { item.value.name.lower() : { 'serial':(prefix_disk + item.value.serial_number).lower(), 'iqn':(item.value.target.iscsi.iqn).lower()} }
+          ) }}
       with_dict: "{{ fusion_info['fusion_info']['volumes'] }}"
 
     - name: Get Purestorage Storage Endpoints
@@ -40,30 +40,30 @@
 
 - hosts: Initiators_Hosts
   become: true
-  tasks: 
-    - set_fact:
-        valid_volumes: {}
-        devices: {}
+  tasks:
+    - ansible.builtin.set_fact:
+        valid_volumes: { }
+        devices: { }
         list_ip: []
         iqn_list: []
-        unmount_report: {}
+        unmount_report: { }
         failed_unmount: []
         reg_fusion_info: "{{ hostvars['localhost']['reg_fusion_info'] }}"
 
     - name: Obtain list of volumes to umount
-      set_fact:
+      ansible.builtin.set_fact:
         valid_volumes: "{{ valid_volumes|combine( {item.name: item.mount_path} ) }}"
-      with_items: "{{ hostvars['localhost']['volumes'] }}" 
+      with_items: "{{ hostvars['localhost']['volumes'] }}"
       when: inventory_hostname in item.host_access_policies
 
     - name: Parse volume, mount path and volume id
-      set_fact:
+      ansible.builtin.set_fact:
         devices: "{{ devices|combine( { valid_volumes[item.key]:item.value } ) }}"
       with_dict: "{{ hostvars['localhost']['map_volumes'] }}"
       when: item.key in valid_volumes.keys()
 
     - name: Volumes to unmount
-      debug:
+      ansible.builtin.debug:
         msg:
           - "Unmount: /dev/mapper/{{ item.value.serial }}-part1"
           - "From: {{ item.key }}"
@@ -71,22 +71,22 @@
 
     - name: Umount volumes
       ansible.posix.mount:
-        path: "{{item.key}}"
+        path: "{{ item.key }}"
         state: unmounted
       register: unmount_report
       with_dict: "{{ devices }}"
-      ignore_errors: True
+      ignore_errors: true
 
-    - name: Obtain a list of volumes that fail to unmount 
-      set_fact:
+    - name: Obtain a list of volumes that fail to unmount
+      ansible.builtin.set_fact:
         failed_unmount: "{{ failed_unmount + [ item.item.key] }}"
       when: item.failed
       with_items: "{{ unmount_report.results }}"
-      delegate_facts: True
+      delegate_facts: true
       delegate_to: localhost
 
     - name: Get a list of IQN with unique elements
-      set_fact:
+      ansible.builtin.set_fact:
         iqn_list: "{{ iqn_list + [ item.value.iqn ] }}"
       with_dict: "{{ devices }}"
       when: item.value.iqn not in iqn_list
@@ -94,23 +94,23 @@
     - name: Disconect to the named target
       community.general.open_iscsi:
         login: false
-        target: "{{item}}"
+        target: "{{ item }}"
       loop: "{{ iqn_list }}"
 
     - name: Obtain IQN from Initiators_Hosts
-      shell: cat /etc/iscsi/initiatorname.iscsi | grep "^InitiatorName=iqn" | awk -F'=' '{print $2}'
+      ansible.builtin.shell: cat /etc/iscsi/initiatorname.iscsi | grep "^InitiatorName=iqn" | awk -F'=' '{print $2}'
       register: iqn
 
     - name: IQN Results
-      debug:
-        msg: "host: {{ansible_hostname}} - iqn: {{iqn.stdout}}"
+      ansible.builtin.debug:
+        msg: "host: {{ ansible_hostname }} - iqn: {{ iqn.stdout }}"
 
 - hosts: localhost
 
   tasks:
-    - include_vars: group_vars/workloads.yml
-    
-    - set_fact:
+    - ansible.builtin.include_vars: group_vars/workloads.yml
+
+    - ansible.builtin.set_fact:
         iqn_data: []
         map_volumes: []
         HAP_undeletable: []
@@ -118,31 +118,31 @@
         TS_undeletable: []
 
     - name: Create IQN/Hostname dictionary
-      set_fact: 
+      ansible.builtin.set_fact:
         iqn_data: "{{ iqn_data|default({}) + [ {'hostname':item, 'iqn':(hostvars[item]['iqn'].stdout)} ] }}"
       with_items:
         - "{{ groups['Initiators_Hosts'] }}"
 
     - name: Create failed_unmount var
-      set_fact:
+      ansible.builtin.set_fact:
         failed_unmount: []
       when: failed_unmount|default('') == ''
 
     - name: Obtain a list of HAP/PG to keep
-      set_fact:
-        HAP_undeletable: "{{HAP_undeletable + item.host_access_policies }}"
-        PG_undeletable: "{{PG_undeletable + [item.placement_group] }}"
-        TS_undeletable: "{{TS_undeletable + [item.tenant_space] }}"
+      ansible.builtin.set_fact:
+        HAP_undeletable: "{{ HAP_undeletable + item.host_access_policies }}"
+        PG_undeletable: "{{ PG_undeletable + [item.placement_group] }}"
+        TS_undeletable: "{{ TS_undeletable + [item.tenant_space] }}"
       with_items: "{{ volumes }}"
       when: item.mount_path in failed_unmount
 
     - name: Volumes safe to remove
-      debug:
+      ansible.builtin.debug:
         msg:
-          - "Name: {{item.name}}"
-          - "Path:{{item.mount_path}}"
+          - "Name: {{ item.name }}"
+          - "Path:{{ item.mount_path }}"
       with_items: "{{ volumes }}"
-      when: 
+      when:
         - item.mount_path not in failed_unmount
         - item.placement_group not in PG_undeletable
         - item.tenant_space not in TS_undeletable
@@ -158,7 +158,7 @@
         tenant: "{{ item.tenant }}"
         tenant_space: "{{ item.tenant_space }}"
         placement_group: "{{ item.placement_group }}"
-        hosts: []
+        host_access_policies: []
         state: "present"
       with_items: "{{ volumes }}"
       when: item.mount_path not in failed_unmount
@@ -174,7 +174,7 @@
         tenant: "{{ item.tenant }}"
         tenant_space: "{{ item.tenant_space }}"
         placement_group: "{{ item.placement_group }}"
-        hosts: "{{ item.host_access_policies }}"
+        host_access_policies: "{{ item.host_access_policies }}"
         state: "absent"
       with_items: "{{ volumes }}"
       when: item.mount_path not in failed_unmount
@@ -186,7 +186,7 @@
         state: "absent"
         name: "{{ item.hostname }}"
         iqn: "{{ item.iqn }}"
-      with_items: "{{iqn_data}}"
+      with_items: "{{ iqn_data }}"
       when: item.hostname not in HAP_undeletable
 
     - name: Delete placement group(s)
@@ -209,5 +209,6 @@
         key_file: "{{ priv_key_file }}"
         state: "absent"
         name: "{{ item.name }}"
+        tenant: "{{ item.tenant }}"
       with_items: "{{ tenant_space }}"
       when: item.name not in TS_undeletable

--- a/ansible/sample_production/teardown_workloads.yml
+++ b/ansible/sample_production/teardown_workloads.yml
@@ -1,11 +1,13 @@
 ---
-- hosts: localhost
-
+- name: Map volumes and endpoints
+  hosts: localhost
   tasks:
-    - ansible.builtin.include_vars: group_vars/workloads.yml
+    - name: Import workload variables
+      ansible.builtin.include_vars: group_vars/workloads.yml
 
-    - ansible.builtin.set_fact:
-        map_volumes: { }
+    - name: Setup local variables
+      ansible.builtin.set_fact:
+        map_volumes: {}
 
     - name: Check private key exists
       ansible.builtin.stat:
@@ -38,15 +40,17 @@
         key_file: "{{ priv_key_file }}"
       register: reg_fusion_info
 
-- hosts: Initiators_Hosts
+- name: Unmount volumes
+  hosts: Initiators_Hosts
   become: true
   tasks:
-    - ansible.builtin.set_fact:
-        valid_volumes: { }
-        devices: { }
+    - name: Setup local variables
+      ansible.builtin.set_fact:
+        valid_volumes: {}
+        devices: {}
         list_ip: []
         iqn_list: []
-        unmount_report: { }
+        unmount_report: {}
         failed_unmount: []
         reg_fusion_info: "{{ hostvars['localhost']['reg_fusion_info'] }}"
 
@@ -98,24 +102,31 @@
       loop: "{{ iqn_list }}"
 
     - name: Obtain IQN from Initiators_Hosts
-      ansible.builtin.shell: cat /etc/iscsi/initiatorname.iscsi | grep "^InitiatorName=iqn" | awk -F'=' '{print $2}'
+      ansible.builtin.shell: >
+        set -o pipefail &&
+        (cat /etc/iscsi/initiatorname.iscsi |
+        grep "^InitiatorName=iqn" |
+        awk -F'=' '{print $2}')
       register: iqn
+      changed_when: false
 
     - name: IQN Results
       ansible.builtin.debug:
         msg: "host: {{ ansible_hostname }} - iqn: {{ iqn.stdout }}"
 
-- hosts: localhost
-
+- name: Teardown environment
+  hosts: localhost
   tasks:
-    - ansible.builtin.include_vars: group_vars/workloads.yml
+    - name: Import workload variables
+      ansible.builtin.include_vars: group_vars/workloads.yml
 
-    - ansible.builtin.set_fact:
+    - name: Setup local variables
+      ansible.builtin.set_fact:
         iqn_data: []
         map_volumes: []
-        HAP_undeletable: []
-        PG_undeletable: []
-        TS_undeletable: []
+        hap_undeletable: []
+        pg_undeletable: []
+        ts_undeletable: []
 
     - name: Create IQN/Hostname dictionary
       ansible.builtin.set_fact:
@@ -126,13 +137,13 @@
     - name: Create failed_unmount var
       ansible.builtin.set_fact:
         failed_unmount: []
-      when: failed_unmount|default('') == ''
+      when: failed_unmount|default('')|length > 0
 
     - name: Obtain a list of HAP/PG to keep
       ansible.builtin.set_fact:
-        HAP_undeletable: "{{ HAP_undeletable + item.host_access_policies }}"
-        PG_undeletable: "{{ PG_undeletable + [item.placement_group] }}"
-        TS_undeletable: "{{ TS_undeletable + [item.tenant_space] }}"
+        hap_undeletable: "{{ hap_undeletable + item.host_access_policies }}"
+        pg_undeletable: "{{ pg_undeletable + [item.placement_group] }}"
+        ts_undeletable: "{{ ts_undeletable + [item.tenant_space] }}"
       with_items: "{{ volumes }}"
       when: item.mount_path in failed_unmount
 
@@ -144,8 +155,8 @@
       with_items: "{{ volumes }}"
       when:
         - item.mount_path not in failed_unmount
-        - item.placement_group not in PG_undeletable
-        - item.tenant_space not in TS_undeletable
+        - item.placement_group not in pg_undeletable
+        - item.tenant_space not in ts_undeletable
 
     - name: Remove HAP from volume(s)
       purestorage.fusion.fusion_volume:
@@ -187,7 +198,7 @@
         name: "{{ item.hostname }}"
         iqn: "{{ item.iqn }}"
       with_items: "{{ iqn_data }}"
-      when: item.hostname not in HAP_undeletable
+      when: item.hostname not in hap_undeletable
 
     - name: Delete placement group(s)
       purestorage.fusion.fusion_pg:
@@ -201,7 +212,7 @@
         availability_zone: "{{ item.availability_zone }}"
         region: "{{ item.region }}"
       with_items: "{{ placement_groups }}"
-      when: item.name not in PG_undeletable
+      when: item.name not in pg_undeletable
 
     - name: Delete tenant space(s)
       purestorage.fusion.fusion_ts:
@@ -211,4 +222,4 @@
         name: "{{ item.name }}"
         tenant: "{{ item.tenant }}"
       with_items: "{{ tenant_space }}"
-      when: item.name not in TS_undeletable
+      when: item.name not in ts_undeletable

--- a/ansible/simple/create_AZ.yml
+++ b/ansible/simple/create_AZ.yml
@@ -2,11 +2,11 @@
 - hosts: localhost
   tasks:
 
-  - name: Create new Availability Zone
-    purestorage.fusion.fusion_az:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      state: present # or absent
-      name: "az2"
-      display_name: "az2"
-      region: region1
+    - name: Create new Availability Zone
+      purestorage.fusion.fusion_az:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        state: present # or absent
+        name: "az2"
+        display_name: "az2"
+        region: region1

--- a/ansible/simple/create_AZ.yml
+++ b/ansible/simple/create_AZ.yml
@@ -1,12 +1,13 @@
 ---
-- hosts: localhost
+- name: Create availability zone
+  hosts: localhost
   tasks:
 
     - name: Create new Availability Zone
       purestorage.fusion.fusion_az:
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-        state: present # or absent
+        state: present  # or absent
         name: "az2"
         display_name: "az2"
         region: region1

--- a/ansible/simple/create_array.yml
+++ b/ansible/simple/create_array.yml
@@ -2,15 +2,15 @@
 - hosts: localhost
   tasks:
 
-  - name: Register array
-    purestorage.fusion.fusion_array:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      state: present # or absent
-      name: flasharray3
-      display_name: "flasharray3"
-      host_name: "flasharray3"
-      hardware_type: flash-array-x
-      appliance_id: 1187351-242133817-5976825671211737520
-      az: az1
-      region: region1
+    - name: Register array
+      purestorage.fusion.fusion_array:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        state: present # or absent
+        name: flasharray3
+        display_name: "flasharray3"
+        host_name: "flasharray3"
+        hardware_type: flash-array-x
+        appliance_id: 1187351-242133817-5976825671211737520
+        az: az1
+        region: region1

--- a/ansible/simple/create_array.yml
+++ b/ansible/simple/create_array.yml
@@ -1,12 +1,13 @@
 ---
-- hosts: localhost
+- name: Create array
+  hosts: localhost
   tasks:
 
     - name: Register array
       purestorage.fusion.fusion_array:
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-        state: present # or absent
+        state: present  # or absent
         name: flasharray3
         display_name: "flasharray3"
         host_name: "flasharray3"

--- a/ansible/simple/create_tenant_space.yml
+++ b/ansible/simple/create_tenant_space.yml
@@ -2,10 +2,10 @@
 - hosts: localhost
   tasks:
 
-  - name: Create new tenant space db_tenant_space for tenant_name
-    purestorage.fusion.fusion_ts:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      state: "present" # or absent
-      name: "db_tenant_space"
-      tenant: "tenant_name"
+    - name: Create new tenant space db_tenant_space for tenant_name
+      purestorage.fusion.fusion_ts:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        state: "present" # or absent
+        name: "db_tenant_space"
+        tenant: "tenant_name"

--- a/ansible/simple/create_tenant_space.yml
+++ b/ansible/simple/create_tenant_space.yml
@@ -1,11 +1,12 @@
 ---
-- hosts: localhost
+- name: Create tenant space
+  hosts: localhost
   tasks:
 
     - name: Create new tenant space db_tenant_space for tenant_name
       purestorage.fusion.fusion_ts:
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-        state: "present" # or absent
+        state: "present"  # or absent
         name: "db_tenant_space"
         tenant: "tenant_name"

--- a/ansible/simple/list_all.yml
+++ b/ansible/simple/list_all.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect all for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: all
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect all for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: all
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_all.yml
+++ b/ansible/simple/list_all.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print all Fusion resources
+  hosts: localhost
   tasks:
     - name: Collect all for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_api_clients.yml
+++ b/ansible/simple/list_api_clients.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect api_clients for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: api_clients
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect api_clients for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: api_clients
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_api_clients.yml
+++ b/ansible/simple/list_api_clients.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print API clients
+  hosts: localhost
   tasks:
     - name: Collect api_clients for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_arrays.yml
+++ b/ansible/simple/list_arrays.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect arrays for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: arrays
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect arrays for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: arrays
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_arrays.yml
+++ b/ansible/simple/list_arrays.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print arrays
+  hosts: localhost
   tasks:
     - name: Collect arrays for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_availability_zones.yml
+++ b/ansible/simple/list_availability_zones.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect Availability Zones for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: zones
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect Availability Zones for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: zones
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_availability_zones.yml
+++ b/ansible/simple/list_availability_zones.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print availability zones
+  hosts: localhost
   tasks:
     - name: Collect Availability Zones for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_hardware_types.yml
+++ b/ansible/simple/list_hardware_types.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect hardware_types for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: hardware_types
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect hardware_types for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: hardware_types
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_hardware_types.yml
+++ b/ansible/simple/list_hardware_types.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print hardware types
+  hosts: localhost
   tasks:
     - name: Collect hardware_types for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_hosts.yml
+++ b/ansible/simple/list_hosts.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect hosts for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: hosts
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect hosts for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: hosts
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_hosts.yml
+++ b/ansible/simple/list_hosts.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: List hosts
+  hosts: localhost
   tasks:
     - name: Collect hosts for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_interfaces.yml
+++ b/ansible/simple/list_interfaces.yml
@@ -1,12 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect interfaces for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: interfaces
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect interfaces for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: interfaces
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
-    
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_interfaces.yml
+++ b/ansible/simple/list_interfaces.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print interfaces
+  hosts: localhost
   tasks:
     - name: Collect interfaces for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_network_interface_groups.yml
+++ b/ansible/simple/list_network_interface_groups.yml
@@ -1,12 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect network_interface_groups for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: network_interface_groups
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect network_interface_groups for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: network_interface_groups
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
-     
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_network_interface_groups.yml
+++ b/ansible/simple/list_network_interface_groups.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print network interface groups
+  hosts: localhost
   tasks:
     - name: Collect network_interface_groups for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_placement_groups.yml
+++ b/ansible/simple/list_placement_groups.yml
@@ -1,12 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect placement_groups for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: placement_groups
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect placement_groups for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: placement_groups
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
-  
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_placement_groups.yml
+++ b/ansible/simple/list_placement_groups.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print placement groups
+  hosts: localhost
   tasks:
     - name: Collect placement_groups for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_protection_policies.yml
+++ b/ansible/simple/list_protection_policies.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect protection_policies for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: protection_policies
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect protection_policies for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: protection_policies
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_protection_policies.yml
+++ b/ansible/simple/list_protection_policies.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print protection policies
+  hosts: localhost
   tasks:
     - name: Collect protection_policies for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_roles.yml
+++ b/ansible/simple/list_roles.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect roles for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: roles
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect roles for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: roles
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_roles.yml
+++ b/ansible/simple/list_roles.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print roles
+  hosts: localhost
   tasks:
     - name: Collect roles for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_snapshots.yml
+++ b/ansible/simple/list_snapshots.yml
@@ -1,12 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect snapshots for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: snapshots
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect snapshots for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: snapshots
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
-    
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_snapshots.yml
+++ b/ansible/simple/list_snapshots.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print snapshots
+  hosts: localhost
   tasks:
     - name: Collect snapshots for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_storage_classes.yml
+++ b/ansible/simple/list_storage_classes.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect storage_classes for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: storage_classes
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect storage_classes for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: storage_classes
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_storage_classes.yml
+++ b/ansible/simple/list_storage_classes.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print storage classes
+  hosts: localhost
   tasks:
     - name: Collect storage_classes for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_storage_endpoints.yml
+++ b/ansible/simple/list_storage_endpoints.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect storage_endpoints for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: storage_endpoints
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect storage_endpoints for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: storage_endpoints
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_storage_endpoints.yml
+++ b/ansible/simple/list_storage_endpoints.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print storage endpoints
+  hosts: localhost
   tasks:
     - name: Collect storage_endpoints for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_storage_services.yml
+++ b/ansible/simple/list_storage_services.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect storage_services for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: storage_services
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect storage_services for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: storage_services
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_storage_services.yml
+++ b/ansible/simple/list_storage_services.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print storage services
+  hosts: localhost
   tasks:
     - name: Collect storage_services for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_tenant_spaces.yml
+++ b/ansible/simple/list_tenant_spaces.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect tenant_spaces for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: tenant_spaces
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect tenant_spaces for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: tenant_spaces
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_tenant_spaces.yml
+++ b/ansible/simple/list_tenant_spaces.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print tenant spaces
+  hosts: localhost
   tasks:
     - name: Collect tenant_spaces for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_tenants.yml
+++ b/ansible/simple/list_tenants.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect tenants for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: tenants
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect tenants for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: tenants
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_tenants.yml
+++ b/ansible/simple/list_tenants.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print tenants
+  hosts: localhost
   tasks:
     - name: Collect tenants for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_users.yml
+++ b/ansible/simple/list_users.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect users for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: users
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect users for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: users
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_users.yml
+++ b/ansible/simple/list_users.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print users
+  hosts: localhost
   tasks:
     - name: Collect users for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_volumes.yml
+++ b/ansible/simple/list_volumes.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect volumes for Pure Storage
-    purestorage.fusion.fusion_info:
-      gather_subset: volumes
-      app_id: "{{ ansible_env.API_CLIENT }}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-    register: fusion_info
+    - name: Collect volumes for Pure Storage
+      purestorage.fusion.fusion_info:
+        gather_subset: volumes
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+      register: fusion_info
 
-  - debug: msg="{{ fusion_info['fusion_info'] }}"
+    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/list_volumes.yml
+++ b/ansible/simple/list_volumes.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Print volumes
+  osts: localhost
   tasks:
     - name: Collect volumes for Pure Storage
       purestorage.fusion.fusion_info:
@@ -8,4 +9,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
       register: fusion_info
 
-    - ansible.builtin.debug: msg="{{ fusion_info['fusion_info'] }}"
+    - name: Print Fusion resources
+      ansible.builtin.debug:
+        msg: "{{ fusion_info['fusion_info'] }}"

--- a/ansible/simple/make_tenant_admin.yml
+++ b/ansible/simple/make_tenant_admin.yml
@@ -3,10 +3,9 @@
   tasks:
     - name: Add tenant-admin role to api-client
       purestorage.fusion.fusion_ra:
-        app_id: "{{ ansible_env.API_CLIENT}}"
-        key_file: "{{ ansible_env.PRIV_KEY_FILE}}"  
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
         state: present
-        name: "tenant-admin" 
+        name: "tenant-admin"
         scope: "organization"  # "organization" "tenant_space"
-        user: "{{ ansible_env.API_CLIENT}}"
-
+        user: "{{ ansible_env.API_CLIENT }}"

--- a/ansible/simple/make_tenant_admin.yml
+++ b/ansible/simple/make_tenant_admin.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Add tenant admin role
+  hosts: localhost
   tasks:
     - name: Add tenant-admin role to api-client
       purestorage.fusion.fusion_ra:

--- a/ansible/simple/remove_array.yml
+++ b/ansible/simple/remove_array.yml
@@ -2,15 +2,15 @@
 - hosts: localhost
   tasks:
 
-  - name: Remove array
-    purestorage.fusion.fusion_array:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      state: absent # or present
-      name: flasharray3
-      display_name: "flasharray3"
-      host_name: "flasharray3"
-      hardware_type: flash-array-x
-      appliance_id: 1187351-242133817-5976825671211737520
-      az: az1
-      region: region1
+    - name: Remove array
+      purestorage.fusion.fusion_array:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        state: absent # or present
+        name: flasharray3
+        display_name: "flasharray3"
+        host_name: "flasharray3"
+        hardware_type: flash-array-x
+        appliance_id: 1187351-242133817-5976825671211737520
+        az: az1
+        region: region1

--- a/ansible/simple/remove_array.yml
+++ b/ansible/simple/remove_array.yml
@@ -1,12 +1,13 @@
 ---
-- hosts: localhost
+- name: Remote array
+  hosts: localhost
   tasks:
 
     - name: Remove array
       purestorage.fusion.fusion_array:
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-        state: absent # or present
+        state: absent  # or present
         name: flasharray3
         display_name: "flasharray3"
         host_name: "flasharray3"

--- a/ansible/simple/setup_infrastructure.yml
+++ b/ansible/simple/setup_infrastructure.yml
@@ -2,56 +2,57 @@
 - hosts: localhost
   tasks:
 
-  - name: Create new region
-    purestorage.fusion.fusion_region:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      state: present # or absent
-      name: region1
-      display_name: "region1"
+    - name: Create new region
+      purestorage.fusion.fusion_region:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        state: present # or absent
+        name: region1
+        display_name: "region1"
 
-  - name: Create new Availability Zone
-    purestorage.fusion.fusion_az:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      state: present # or absent
-      name: az1
-      display_name: "az1"
+    - name: Create new Availability Zone
+      purestorage.fusion.fusion_az:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        state: present # or absent
+        name: az1
+        display_name: "az1"
 
-  - name: Create new network interface group
-    purestorage.fusion.fusion_nig:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      state: present # or absent
-      name: "interface_group1"
-      availability_zone: "az1"
-      region: region1
-      mtu: 1500
-      gateway: 172.17.1.1
-      prefix: 172.17.1.0/24
+    - name: Create new network interface group
+      purestorage.fusion.fusion_nig:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        state: present # or absent
+        name: "interface_group1"
+        availability_zone: "az1"
+        region: region1
+        mtu: 1500
+        gateway: 172.17.1.1
+        prefix: 172.17.1.0/24
 
-  - name: Create new Storage Endpoint
-    purestorage.fusion.fusion_se:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      state: present # or absent
-      name: default
-      display_name: default
-      availability_zone: az1
-      gateway: 172.17.1.1
-      addresses: ["172.17.1.2/24", "172.17.1.1/24"]
-      network_interface_groups: ["interface_group1"]
-      endpoint_type: iscsi
+    - name: Create new Storage Endpoint
+      purestorage.fusion.fusion_se:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        state: present # or absent
+        region: region1
+        name: default
+        display_name: default
+        availability_zone: az1
+        gateway: 172.17.1.1
+        addresses: ["172.17.1.2/24", "172.17.1.1/24"]
+        network_interface_groups: ["interface_group1"]
+        endpoint_type: iscsi
 
-  - name: Register new array
-    purestorage.fusion.fusion_array:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      state: present # or absent
-      name: flasharray1
-      display_name: "flasharray1"
-      az: az1
-      hardware_type: flash-array-x
-      appliance_id: 1187351-242133817-5976825671211737520
-      region: region1
-      host_name: flasharray1
+    - name: Register new array
+      purestorage.fusion.fusion_array:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        state: present # or absent
+        name: flasharray1
+        display_name: "flasharray1"
+        az: az1
+        hardware_type: flash-array-x
+        appliance_id: 1187351-242133817-5976825671211737520
+        region: region1
+        host_name: flasharray1

--- a/ansible/simple/setup_infrastructure.yml
+++ b/ansible/simple/setup_infrastructure.yml
@@ -1,12 +1,13 @@
 ---
-- hosts: localhost
+- name: Setup Fusion resources
+  hosts: localhost
   tasks:
 
     - name: Create new region
       purestorage.fusion.fusion_region:
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-        state: present # or absent
+        state: present  # or absent
         name: region1
         display_name: "region1"
 
@@ -14,7 +15,7 @@
       purestorage.fusion.fusion_az:
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-        state: present # or absent
+        state: present  # or absent
         name: az1
         display_name: "az1"
 
@@ -22,7 +23,7 @@
       purestorage.fusion.fusion_nig:
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-        state: present # or absent
+        state: present  # or absent
         name: "interface_group1"
         availability_zone: "az1"
         region: region1
@@ -34,7 +35,7 @@
       purestorage.fusion.fusion_se:
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-        state: present # or absent
+        state: present  # or absent
         region: region1
         name: default
         display_name: default
@@ -48,7 +49,7 @@
       purestorage.fusion.fusion_array:
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
-        state: present # or absent
+        state: present  # or absent
         name: flasharray1
         display_name: "flasharray1"
         az: az1

--- a/ansible/simple/setup_protection_policies.yml
+++ b/ansible/simple/setup_protection_policies.yml
@@ -1,12 +1,12 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Create new Protection Policy PP_name
-    purestorage.fusion.fusion_pp:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      name: "PP_name"
-      display_name: "PP_name"
-      local_rpo: "15" # in minutes
-      local_retention: "24h" # m(inutes), h(ours), d(ays), w(eeks), or y(ears).
-      state: present # or absent
+    - name: Create new Protection Policy PP_name
+      purestorage.fusion.fusion_pp:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        name: "PP_name"
+        display_name: "PP_name"
+        local_rpo: "15" # in minutes
+        local_retention: "24h" # m(inutes), h(ours), d(ays), w(eeks), or y(ears).
+        state: present # or absent

--- a/ansible/simple/setup_protection_policies.yml
+++ b/ansible/simple/setup_protection_policies.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Create protection policy
+  hosts: localhost
   tasks:
     - name: Create new Protection Policy PP_name
       purestorage.fusion.fusion_pp:
@@ -7,6 +8,6 @@
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
         name: "PP_name"
         display_name: "PP_name"
-        local_rpo: "15" # in minutes
-        local_retention: "24h" # m(inutes), h(ours), d(ays), w(eeks), or y(ears).
-        state: present # or absent
+        local_rpo: "15"  # in minutes
+        local_retention: "24h"  # m(inutes), h(ours), d(ays), w(eeks) or y(ears)
+        state: present  # or absent

--- a/ansible/simple/setup_storage_service_class.yml
+++ b/ansible/simple/setup_storage_service_class.yml
@@ -1,23 +1,23 @@
 ---
 - hosts: localhost
   tasks:
-  - name:  Create new storage service called storage_service_1
-    purestorage.fusion.fusion_ss:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      name: storage_service_1
-      display_name: "storage_service_1"
-      hardware_types: flash-array-c
-      state: present # or absent
+    - name: Create new storage service called storage_service_1
+      purestorage.fusion.fusion_ss:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        name: storage_service_1
+        display_name: "storage_service_1"
+        hardware_types: flash-array-c
+        state: present # or absent
 
-  - name: Create new storage class storage_class_1
-    purestorage.fusion.fusion_sc:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      name: storage_class_1
-      display_name: "storage_class_1"
-      storage_service: storage_service_1
-      size_limit: 100M #100M 100G 100T 100P - Default 4PB
-      iops_limit: 10000 #Must be between 100 and 100000000.
-      bw_limit: 4194M # 524288000
-      state: present # or absent
+    - name: Create new storage class storage_class_1
+      purestorage.fusion.fusion_sc:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        name: storage_class_1
+        display_name: "storage_class_1"
+        storage_service: storage_service_1
+        size_limit: 100M # 100M 100G 100T 100P - Default 4PB
+        iops_limit: 10000 # Must be between 100 and 100000000.
+        bw_limit: 4194M # 524288000
+        state: present # or absent

--- a/ansible/simple/setup_storage_service_class.yml
+++ b/ansible/simple/setup_storage_service_class.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Create storage service & class
+  hosts: localhost
   tasks:
     - name: Create new storage service called storage_service_1
       purestorage.fusion.fusion_ss:
@@ -8,7 +9,7 @@
         name: storage_service_1
         display_name: "storage_service_1"
         hardware_types: flash-array-c
-        state: present # or absent
+        state: present  # or absent
 
     - name: Create new storage class storage_class_1
       purestorage.fusion.fusion_sc:
@@ -17,7 +18,7 @@
         name: storage_class_1
         display_name: "storage_class_1"
         storage_service: storage_service_1
-        size_limit: 100M # 100M 100G 100T 100P - Default 4PB
-        iops_limit: 10000 # Must be between 100 and 100000000.
-        bw_limit: 4194M # 524288000
-        state: present # or absent
+        size_limit: 100M  # 100M 100G 100T 100P - Default 4PB
+        iops_limit: 10000  # Must be between 100 and 100000000.
+        bw_limit: 4194M  # 524288000
+        state: present  # or absent

--- a/ansible/simple/setup_workloads.yml
+++ b/ansible/simple/setup_workloads.yml
@@ -15,56 +15,56 @@
 
   tasks:
 
-  - name: Create new tenant space db_tenant_space for oracle_dbas
-    purestorage.fusion.fusion_ts:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      name: "db_tenant_space"
-      tenant: "oracle_dbas"
-      state: "present" # or absent
+    - name: Create new tenant space db_tenant_space for oracle_dbas
+      purestorage.fusion.fusion_ts:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        name: "db_tenant_space"
+        tenant: "oracle_dbas"
+        state: "present" # or absent
 
-  - name: Create new placement group named pg1
-    purestorage.fusion.fusion_pg:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      name: "pg1"
-      tenant: "oracle_dbas"
-      tenant_space: "db_tenant_space"
-      region: "region1"
-      availability_zone: "az1"
-      state: "present" # or absent
+    - name: Create new placement group named pg1
+      purestorage.fusion.fusion_pg:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        name: "pg1"
+        tenant: "oracle_dbas"
+        tenant_space: "db_tenant_space"
+        region: "region1"
+        availability_zone: "az1"
+        state: "present" # or absent
 
-  - name: Create new host access policy
-    purestorage.fusion.fusion_hap:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      name: "customer_host_access"
-      personality: "linux"
-      iqn: "iqn.1994-05.com.redhat:9dd57693efb"
-      state: "present" # or absent
+    - name: Create new host access policy
+      purestorage.fusion.fusion_hap:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        name: "customer_host_access"
+        personality: "linux"
+        iqn: "iqn.1994-05.com.redhat:9dd57693efb"
+        state: "present" # or absent
 
-  - name: Create new volume named data_vol1 in storage_class db_high_performance
-    purestorage.fusion.fusion_volume:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      name: "data_vol1"
-      storage_class: "db_high_performance"
-      size: "500G" # Volume size in M, G, T or P units.
-      tenant: "oracle_dbas"
-      tenant_space: "db_tenant_space"
-      placement_group: "pg1"
-      hosts: "customer_host_access"
-      state: "present" # or absent
+    - name: Create new volume named data_vol1 in storage_class db_high_performance
+      purestorage.fusion.fusion_volume:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        name: "data_vol1"
+        storage_class: "db_high_performance"
+        size: "500G" # Volume size in M, G, T or P units.
+        tenant: "oracle_dbas"
+        tenant_space: "db_tenant_space"
+        placement_group: "pg1"
+        host_access_policies: "customer_host_access"
+        state: "present" # or absent
 
-  - name: Create new volume named data_vol2 in storage_class db_high_performance
-    purestorage.fusion.fusion_volume:
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
-      name: "data_vol2"
-      storage_class: "db_high_performance"
-      size: "500G" # Volume size in M, G, T or P units.
-      tenant: "oracle_dbas"
-      tenant_space: "db_tenant_space"
-      placement_group: "pg1"
-      hosts: "customer_host_access"
-      state: "present" # or absent
+    - name: Create new volume named data_vol2 in storage_class db_high_performance
+      purestorage.fusion.fusion_volume:
+        app_id: "{{ ansible_env.API_CLIENT }}"
+        key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
+        name: "data_vol2"
+        storage_class: "db_high_performance"
+        size: "500G" # Volume size in M, G, T or P units.
+        tenant: "oracle_dbas"
+        tenant_space: "db_tenant_space"
+        placement_group: "pg1"
+        host_access_policies: "customer_host_access"
+        state: "present" # or absent

--- a/ansible/simple/setup_workloads.yml
+++ b/ansible/simple/setup_workloads.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Setup workloads
+  hosts: localhost
   # This playbook create:
 
   # *- Tenant space: db_tenant_space
@@ -14,14 +15,13 @@
   # *- Region: region1
 
   tasks:
-
     - name: Create new tenant space db_tenant_space for oracle_dbas
       purestorage.fusion.fusion_ts:
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
         name: "db_tenant_space"
         tenant: "oracle_dbas"
-        state: "present" # or absent
+        state: "present"  # or absent
 
     - name: Create new placement group named pg1
       purestorage.fusion.fusion_pg:
@@ -32,7 +32,8 @@
         tenant_space: "db_tenant_space"
         region: "region1"
         availability_zone: "az1"
-        state: "present" # or absent
+        storage_service: "db_xl"
+        state: "present"  # or absent
 
     - name: Create new host access policy
       purestorage.fusion.fusion_hap:
@@ -41,30 +42,30 @@
         name: "customer_host_access"
         personality: "linux"
         iqn: "iqn.1994-05.com.redhat:9dd57693efb"
-        state: "present" # or absent
+        state: "present"  # or absent
 
-    - name: Create new volume named data_vol1 in storage_class db_high_performance
+    - name: Create new volume data_vol1 in storage_class db_high_performance
       purestorage.fusion.fusion_volume:
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
         name: "data_vol1"
         storage_class: "db_high_performance"
-        size: "500G" # Volume size in M, G, T or P units.
+        size: "500G"  # Volume size in M, G, T or P units.
         tenant: "oracle_dbas"
         tenant_space: "db_tenant_space"
         placement_group: "pg1"
         host_access_policies: "customer_host_access"
-        state: "present" # or absent
+        state: "present"  # or absent
 
-    - name: Create new volume named data_vol2 in storage_class db_high_performance
+    - name: Create new volume data_vol2 in storage_class db_high_performance
       purestorage.fusion.fusion_volume:
         app_id: "{{ ansible_env.API_CLIENT }}"
         key_file: "{{ ansible_env.PRIV_KEY_FILE }}"
         name: "data_vol2"
         storage_class: "db_high_performance"
-        size: "500G" # Volume size in M, G, T or P units.
+        size: "500G"  # Volume size in M, G, T or P units.
         tenant: "oracle_dbas"
         tenant_space: "db_tenant_space"
         placement_group: "pg1"
         host_access_policies: "customer_host_access"
-        state: "present" # or absent
+        state: "present"  # or absent

--- a/ansible/smoke_test.yml
+++ b/ansible/smoke_test.yml
@@ -1,8 +1,8 @@
 ---
 - hosts: localhost
   tasks:
-  - name: Collect basic information as part of smoke test
-    purestorage.fusion.fusion_info:
+   - name: Collect basic information as part of smoke test
+     purestorage.fusion.fusion_info:
       gather_subset: minimum
-      app_id: "{{ ansible_env.API_CLIENT}}"
-      key_file: "{{ ansible_env.PRIV_KEY_FILE}}"
+      app_id: "{{ ansible_env.API_CLIENT }}"
+      key_file: "{{ ansible_env.PRIV_KEY_FILE }}"

--- a/ansible/smoke_test.yml
+++ b/ansible/smoke_test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Smoke test
+  hosts: localhost
   tasks:
    - name: Collect basic information as part of smoke test
      purestorage.fusion.fusion_info:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,24 @@
 version: "3"
 services:
-    centos_eee:
-      build: .
-      container_name: purestorage_fusion_lab
-      environment:
-        - API_CLIENT=pure1:apikey:1234567891234567
-      volumes:
-        - ./private_key.pem:/workdir/private_key.pem:ro
-        - ./python:/fusion_python
-        - ./ansible:/fusion_ansible
-      command:
-        /bin/bash -c "cd /workdir &&
-                chmod +x /usr/bin/hmctl &&
-                sed -i \"s/API_CLIENT/$$API_CLIENT/g\" /root/.pure/fusion.json &&
-                python3 /fusion_python/00_smoke_test.py &&
-                hmctl region list &&
-                ansible-playbook /fusion_ansible/smoke_test.yml &&
-                echo Service ready &&
-                tail -f /dev/null"
+  centos_eee:
+    build: .
+    container_name: purestorage_fusion_lab
+    environment:
+      - API_CLIENT=pure1:apikey:1234567891234567
+    volumes:
+      - ./private_key.pem:/workdir/private_key.pem:ro
+      - ./python:/fusion_python
+      - ./ansible:/fusion_ansible
+    command:
+      /bin/bash -c "cd /workdir &&
+      chmod +x /usr/bin/hmctl &&
+      sed -i \"s/API_CLIENT/$$API_CLIENT/g\" /root/.pure/fusion.json &&
+      python3 /fusion_python/00_smoke_test.py &&
+      hmctl region list &&
+      ansible-playbook /fusion_ansible/smoke_test.yml &&
+      echo Service ready &&
+      tail -f /dev/null"
 
 
-#docker exec -it purestorage_fusion_lab python3 /fusion_python/00_smoke_test.py
-#docker exec -it purestorage_fusion_lab hmctl region list
+# docker exec -it purestorage_fusion_lab python3 /fusion_python/00_smoke_test.py
+# docker exec -it purestorage_fusion_lab hmctl region list

--- a/python/config/infrastructure.yaml
+++ b/python/config/infrastructure.yaml
@@ -3,34 +3,34 @@
 - name: region1
   display_name: region1
   availability_zones:
-  - name: az1
-    display_name: az1
-    storage_endpoints:
-    - name: default
-      display_name: default
-      endpoint_type: iscsi
-      iscsi:
-      - address: 172.17.1.1/24
-        network_interface_groups:
-        - interface_group1
-      - address: 172.17.1.2/24
-        network_interface_groups:
-        - interface_group1
-    network_interface_groups:
-    - name: interface_group1
-      display_name: interface_group1
-      group_type: eth
-      eth:
-        prefix: 172.17.1.0/24
-        mtu: 1500
-    arrays:
-    - name: flasharray1
-      display_name: flasharray1
-      appliance_id: 1187351-242133817-5976825671211737520
-      host_name: flasharray1
-      hardware_type: flash-array-x
-    - name: flasharray2
-      display_name: flasharray2
-      appliance_id: 4044399-202674005-8936155360115641845
-      host_name: flasharray2
-      hardware_type: flash-array-x
+    - name: az1
+      display_name: az1
+      storage_endpoints:
+        - name: default
+          display_name: default
+          endpoint_type: iscsi
+          iscsi:
+            - address: 172.17.1.1/24
+              network_interface_groups:
+                - interface_group1
+            - address: 172.17.1.2/24
+              network_interface_groups:
+                - interface_group1
+      network_interface_groups:
+        - name: interface_group1
+          display_name: interface_group1
+          group_type: eth
+          eth:
+            prefix: 172.17.1.0/24
+            mtu: 1500
+      arrays:
+        - name: flasharray1
+          display_name: flasharray1
+          appliance_id: 1187351-242133817-5976825671211737520
+          host_name: flasharray1
+          hardware_type: flash-array-x
+        - name: flasharray2
+          display_name: flasharray2
+          appliance_id: 4044399-202674005-8936155360115641845
+          host_name: flasharray2
+          hardware_type: flash-array-x

--- a/python/config/policy.yaml
+++ b/python/config/policy.yaml
@@ -1,87 +1,87 @@
 ---
 # Storage Policies (Storage Services and Storage Classes)
 storage_services:
-- name: flash_performance
-  display_name: flash_performance
-  hardware_types:
-  - flash-array-x
-  storage_classes:
-  - name: db_high_performance
-    display_name: db_high_performance
-    iops_limit: 10000
-    bandwidth_limit: 524288000
-    size_limit: 100000000000000
-  - name: db_standard
-    display_name: db_standard
-    iops_limit: 5000
-    bandwidth_limit: 262144000
-    size_limit: 100000000000000
-  - name: db_bulk
-    display_name: db_bulk
-    iops_limit: 1000
-    bandwidth_limit: 52428800
-    size_limit: 100000000000000
-- name: flash_capacity
-  display_name: flash_capacity
-  hardware_types:
-  - flash-array-c
-  storage_classes:
-  - name: db_high_performance
-    display_name: db_high_performance
-    iops_limit: 10000
-    bandwidth_limit: 524288000
-    size_limit: 100000000000000
-  - name: db_standard
-    display_name: db_standard
-    iops_limit: 5000
-    bandwidth_limit: 262144000
-    size_limit: 100000000000000
-  - name: db_bulk
-    display_name: db_bulk
-    iops_limit: 1000
-    bandwidth_limit: 52428800
-    size_limit: 100000000000000
-- name: generic
-  display_name: generic
-  hardware_types:
-  - flash-array-x
-  - flash-array-c
-  storage_classes:
-  - name: db_high_performance
-    display_name: db_high_performance
-    iops_limit: 10000
-    bandwidth_limit: 524288000
-    size_limit: 100000000000000
-  - name: db_standard
-    display_name: db_standard
-    iops_limit: 5000
-    bandwidth_limit: 262144000
-    size_limit: 100000000000000
-  - name: db_bulk
-    display_name: db_bulk
-    iops_limit: 1000
-    bandwidth_limit: 52428800
-    size_limit: 100000000000000
+  - name: flash_performance
+    display_name: flash_performance
+    hardware_types:
+      - flash-array-x
+    storage_classes:
+      - name: db_high_performance
+        display_name: db_high_performance
+        iops_limit: 10000
+        bandwidth_limit: 524288000
+        size_limit: 100000000000000
+      - name: db_standard
+        display_name: db_standard
+        iops_limit: 5000
+        bandwidth_limit: 262144000
+        size_limit: 100000000000000
+      - name: db_bulk
+        display_name: db_bulk
+        iops_limit: 1000
+        bandwidth_limit: 52428800
+        size_limit: 100000000000000
+  - name: flash_capacity
+    display_name: flash_capacity
+    hardware_types:
+      - flash-array-c
+    storage_classes:
+      - name: db_high_performance
+        display_name: db_high_performance
+        iops_limit: 10000
+        bandwidth_limit: 524288000
+        size_limit: 100000000000000
+      - name: db_standard
+        display_name: db_standard
+        iops_limit: 5000
+        bandwidth_limit: 262144000
+        size_limit: 100000000000000
+      - name: db_bulk
+        display_name: db_bulk
+        iops_limit: 1000
+        bandwidth_limit: 52428800
+        size_limit: 100000000000000
+  - name: generic
+    display_name: generic
+    hardware_types:
+      - flash-array-x
+      - flash-array-c
+    storage_classes:
+      - name: db_high_performance
+        display_name: db_high_performance
+        iops_limit: 10000
+        bandwidth_limit: 524288000
+        size_limit: 100000000000000
+      - name: db_standard
+        display_name: db_standard
+        iops_limit: 5000
+        bandwidth_limit: 262144000
+        size_limit: 100000000000000
+      - name: db_bulk
+        display_name: db_bulk
+        iops_limit: 1000
+        bandwidth_limit: 52428800
+        size_limit: 100000000000000
 # Protection Policies
 protection_policies:
-- name: db_fifteen
-  display_name: db_fifteen
-  objectives:
-  - type: RPO
-    rpo: PT15M
-  - type: Retention
-    after: PT24H
-- name: hourly_for_a_week
-  display_name: hourly_for_a_week
-  objectives:
-  - type: RPO
-    rpo: PT1H
-  - type: Retention
-    after: PT168H
-- name: daily_for_a_month
-  display_name: daily_for_a_month
-  objectives:
-  - type: RPO
-    rpo: PT24H
-  - type: Retention
-    after: PT730H
+  - name: db_fifteen
+    display_name: db_fifteen
+    objectives:
+      - type: RPO
+        rpo: PT15M
+      - type: Retention
+        after: PT24H
+  - name: hourly_for_a_week
+    display_name: hourly_for_a_week
+    objectives:
+      - type: RPO
+        rpo: PT1H
+      - type: Retention
+        after: PT168H
+  - name: daily_for_a_month
+    display_name: daily_for_a_month
+    objectives:
+      - type: RPO
+        rpo: PT24H
+      - type: Retention
+        after: PT730H

--- a/python/config/workloads.yaml
+++ b/python/config/workloads.yaml
@@ -4,38 +4,38 @@
   display_name: db_tenant_space
   tenant: oracle_dbas
   placement_groups:
-  - name: pg1
-    display_name: pg1
-    region: region1
-    availability_zone: az1
-    storage_service: flash_performance
+    - name: pg1
+      display_name: pg1
+      region: region1
+      availability_zone: az1
+      storage_service: flash_performance
   volumes:
-  - name: data_vol1
-    display_name: data_vol1
-    size: 5000000000000
-    storage_class: db_high_performance
-    placement_group: pg1
-    host_access_policies: customer_host_access
-  - name: data_vol2
-    display_name: data_vol2
-    size: 5000000000000
-    storage_class: db_high_performance
-    placement_group: pg1
-    host_access_policies: customer_host_access
-  - name: log_vol
-    display_name: log_vol
-    size: 5000000000000
-    storage_class: db_standard
-    placement_group: pg1
-    host_access_policies: customer_host_access
-  - name: config_vol
-    display_name: config_vol
-    size: 500000000000
-    storage_class: db_bulk
-    placement_group: pg1
-    host_access_policies: customer_host_access
+    - name: data_vol1
+      display_name: data_vol1
+      size: 5000000000000
+      storage_class: db_high_performance
+      placement_group: pg1
+      host_access_policies: customer_host_access
+    - name: data_vol2
+      display_name: data_vol2
+      size: 5000000000000
+      storage_class: db_high_performance
+      placement_group: pg1
+      host_access_policies: customer_host_access
+    - name: log_vol
+      display_name: log_vol
+      size: 5000000000000
+      storage_class: db_standard
+      placement_group: pg1
+      host_access_policies: customer_host_access
+    - name: config_vol
+      display_name: config_vol
+      size: 500000000000
+      storage_class: db_bulk
+      placement_group: pg1
+      host_access_policies: customer_host_access
   host_access_policies:
-  - name: customer_host_access
-    display_name: customer_host_access
-    iqn: iqn.1994-05.com.redhat:9dd57693efb
-    personality: linux
+    - name: customer_host_access
+      display_name: customer_host_access
+      iqn: iqn.1994-05.com.redhat:9dd57693efb
+      personality: linux


### PR DESCRIPTION
Cleans up most `ansible-lint` errors in /ansible folder.
Joint work with @andreepyro.
Ansible-lint version:
`$ ansible --version`
`ansible-lint 6.12.2 using ansible 2.14.2`
Only one experimental lint error remains which is a bug in the linter itself - it cannot handle dynamic enum variants and treats them as literals.