### PR TITLE
Improve private-key finding

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ For Windows:
 5) Copy the private-key.pem file
 ```
 - Key must have `.pem` extension. 
-- As an alternative `PRIVATE_KEY_FILE=<key-file-name>` environment variable can be used, to specify exact file name of private key.- Key must have `.pem` extension. 
+- As an alternative `PRIVATE_KEY_FILE=<key-file-name>` environment variable can be used, to specify exact file name of private key.
 ### Spin up the Container
 
 _For the command lines below, replace <image_name> with either 'quay.io/purestorage/fusion-devkit' (if pulled from quay.io), or 'fusion-devkit' if downloaded manually from the GitHub repository._

--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ For Linux:
 cd $HOME
 mkdir api-client
 echo API_CLIENT_ID > api-client/issuer
-cp PATH_TO_PRIV_KEY api-client/
+cp PATH_TO_PRIV_KEY/private-key.pem  api-client/
 ```
+- Key must have `.pem` extension. 
+- As an alternative `PRIVATE_KEY_FILE=<key-file-name>` environment variable can be used, to specify exact file name of private key.
+
 For Windows:
 ```
 1) Open a command prompt or PowerShell window
@@ -66,6 +69,8 @@ For Windows:
 4) Copy the APP ID to a new file called "issuer" (no file extension)
 5) Copy the private-key.pem file
 ```
+- Key must have `.pem` extension. 
+- As an alternative `PRIVATE_KEY_FILE=<key-file-name>` environment variable can be used, to specify exact file name of private key.- Key must have `.pem` extension. 
 ### Spin up the Container
 
 _For the command lines below, replace <image_name> with either 'quay.io/purestorage/fusion-devkit' (if pulled from quay.io), or 'fusion-devkit' if downloaded manually from the GitHub repository._

--- a/docker-entrypoint/50-fusion.sh
+++ b/docker-entrypoint/50-fusion.sh
@@ -18,7 +18,10 @@ if [ -n "$PRIVATE_KEY_FILE" ] && [ -f "$clientDir/$PRIVATE_KEY_FILE" ]; then
 elif [ -f "$clientDir/private-key.pem" ]; then
   keyFile="private-key.pem"
 else
-  keyFile=$(basename $(find "$clientDir" -type f -iname "*.pem" | head -n 1))
+  file=$(find "$clientDir" -type f -iname "*.pem" | head -n 1)
+  if [ -n "$file" ]; then 
+    keyFile=$(basename $file)
+  fi
 fi
 
 if [ -z "$keyFile" ] || [ ! -f "$clientDir/$keyFile" ]; then


### PR DESCRIPTION
Private key finding improved
1. User can add `PRIVATE_KEY_FILE` env variable to for key-name in client dir.
2. If var `PRIVATE_KEY_FILE` doesn't exist, `private-key.pem` file has a priority in key choosing
3. If `private-key.pem` file doesn't exist, first file with`*pem` extension has a priority in key choosing