### PR TITLE
Fix linter errors in playbooks

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  - purestorage.fusion
+  - community.crypto
+  - community.general
+  - ansible.posix

--- a/ansible/sample_production/group_vars/storage_service_class.yml
+++ b/ansible/sample_production/group_vars/storage_service_class.yml
@@ -2,11 +2,11 @@
 storage_service:
   - name: Storage-C
     display_name: Storage C
-    hardware_types: 
+    hardware_types:
       - flash-array-c
   - name: Storage-X
     display_name: Storage X
-    hardware_types: 
+    hardware_types:
       - flash-array-x
   - name: generic
     display_name: generic
@@ -19,7 +19,7 @@ storage_class:
   - name: capacity
     display_name: capacity
     storage_service: Storage-C
-    iops_limit: 1000  
+    iops_limit: 1000
     bw_limit: 100M
     size_limit: 5T
   - name: boot

--- a/ansible/sample_production/setup_consumer.yml
+++ b/ansible/sample_production/setup_consumer.yml
@@ -22,13 +22,13 @@
       ansible.builtin.file:
         path: "{{ workdir }}"
         state: directory
-        mode: 0755
+        mode: "0755"
 
     - name: "Creates tenants folders"
       ansible.builtin.file:
         path: "{{ workdir }}/{{ item.name }}"
         state: directory
-        mode: 0755
+        mode: "0755"
       loop: "{{ tenants }}"
 
     - name: Create new tenant(s)
@@ -79,7 +79,7 @@
       ansible.builtin.copy:
         dest: "{{ workdir }}/{{ item.value.display_name }}/{{ item.value.display_name }}.iss"
         content: "{{ item.value.issuer }}"
-        mode: 0644
+        mode: "0644"
       with_dict: "{{ fusion_info['fusion_info']['api_clients'] }}"
       when: item.value.display_name in tenants_dict.keys()
 

--- a/ansible/sample_production/setup_host_access_policies.yml
+++ b/ansible/sample_production/setup_host_access_policies.yml
@@ -43,7 +43,7 @@
 
     - name: Create IQN/Hostname dictionary
       ansible.builtin.set_fact:
-        iqn_data: "{{ iqn_data|default({}) + [ {'hostname':item, 'iqn':(hostvars[item]['iqn'].stdout)} ] }}"
+        iqn_data: "{{ iqn_data | default([]) + [{'hostname': item, 'iqn': (hostvars[item]['iqn'].stdout)}] }}"
       with_items:
         - "{{ groups['Initiators_Hosts'] }}"
 
@@ -57,4 +57,4 @@
         personality: "linux"
         iqn: "{{ item.iqn }}"
       with_items: "{{ iqn_data }}"
-      when: item.iqn|length > 0
+      when: item.iqn | length > 0

--- a/ansible/sample_production/setup_infrastructure.yml
+++ b/ansible/sample_production/setup_infrastructure.yml
@@ -77,7 +77,7 @@
       loop: "{{ arrays }}"
 
     - name: Assign network interface(s) to network interface group(s)
-      include_tasks: setup_network_interfaces.yml
+      ansible.builtin.include_tasks: setup_network_interfaces.yml
       loop: "{{ arrays }}"
       loop_control:
         loop_var: array

--- a/ansible/sample_production/setup_workloads.yml
+++ b/ansible/sample_production/setup_workloads.yml
@@ -43,7 +43,7 @@
 
     - name: Create IQN/Hostname dictionary
       ansible.builtin.set_fact:
-        iqn_data: "{{ iqn_data|default({}) + [ {'hostname':item, 'iqn':(hostvars[item]['iqn'].stdout)} ] }}"
+        iqn_data: "{{ iqn_data | default([]) + [{'hostname': item, 'iqn': (hostvars[item]['iqn'].stdout)}] }}"
       with_items:
         - "{{ groups['Initiators_Hosts'] }}"
 
@@ -57,7 +57,7 @@
         personality: "linux"
         iqn: "{{ item.iqn }}"
       with_items: "{{ iqn_data }}"
-      when: item.iqn|length > 0
+      when: item.iqn | length > 0
 
     - name: Create new tenant space(s)
       purestorage.fusion.fusion_ts:
@@ -108,8 +108,8 @@
     - name: Map Volumes with (Serial ID and IQN )
       ansible.builtin.set_fact:
         map_volumes: >-
-          {{ map_volumes|combine(
-          { item.value.name.lower() : { 'serial':item.value.serial_number, 'iqn':(item.value.target.iscsi.iqn).lower()} }
+          {{ map_volumes | combine(
+            {item.value.name.lower(): {'serial': item.value.serial_number, 'iqn': (item.value.target.iscsi.iqn).lower()}}
           ) }}
       with_dict: "{{ fusion_info['fusion_info']['volumes'] }}"
 
@@ -135,7 +135,7 @@
 
     - name: Obtain list of volumes to mount
       ansible.builtin.set_fact:
-        valid_volumes: "{{ valid_volumes|combine( {item.name: item.mount_path} ) }}"
+        valid_volumes: "{{ valid_volumes | combine({item.name: item.mount_path}) }}"
       with_items: "{{ hostvars['localhost']['volumes'] }}"
       when: inventory_hostname in item.host_access_policies
 
@@ -145,7 +145,7 @@
 
     - name: Parse volume, mount path and volume id
       ansible.builtin.set_fact:
-        devices: "{{ devices|combine( { valid_volumes[item.key]:item.value } ) }}"
+        devices: "{{ devices | combine({valid_volumes[item.key]: item.value}) }}"
       with_dict: "{{ hostvars['localhost']['map_volumes'] }}"
       when: item.key in valid_volumes.keys()
 
@@ -175,7 +175,7 @@
 
     - name: Get a list of IQN with unique elements
       ansible.builtin.set_fact:
-        iqn_list: "{{ iqn_list + [ item.value.iqn ] }}"
+        iqn_list: "{{ iqn_list + [item.value.iqn] }}"
       with_dict: "{{ devices }}"
       when: item.value.iqn not in iqn_list
 
@@ -195,7 +195,7 @@
       ansible.builtin.file:
         path: "{{ item.key }}"
         state: directory
-        mode: 0755
+        mode: "0755"
       with_dict: "{{ devices }}"
 
     - name: Mount volumes
@@ -215,11 +215,11 @@
       ansible.builtin.copy:
         src: "./files/initiator_random_write.fio"
         dest: "/tmp/initiator_random_write.fio"
-        mode: 0644
+        mode: "0644"
 
     - name: Run FIO process
       when: run_fio is true
-      ansible.builtin.shell:
+      ansible.builtin.command:
         chdir: "{{ item.mount_path }}"
         cmd: "fio /tmp/initiator_random_write.fio"
       with_items: "{{ hostvars['localhost']['volumes'] }}"

--- a/ansible/sample_production/teardown_workloads.yml
+++ b/ansible/sample_production/teardown_workloads.yml
@@ -28,8 +28,8 @@
     - name: Map Volumes with (Serial ID and IQN )
       ansible.builtin.set_fact:
         map_volumes: >-
-          {{ map_volumes|combine(
-          { item.value.name.lower() : { 'serial':item.value.serial_number, 'iqn':(item.value.target.iscsi.iqn).lower()} }
+          {{ map_volumes | combine(
+            {item.value.name.lower() : {'serial': item.value.serial_number, 'iqn': (item.value.target.iscsi.iqn).lower()}}
           ) }}
       with_dict: "{{ fusion_info['fusion_info']['volumes'] }}"
 
@@ -56,13 +56,13 @@
 
     - name: Obtain list of volumes to umount
       ansible.builtin.set_fact:
-        valid_volumes: "{{ valid_volumes|combine( {item.name: item.mount_path} ) }}"
+        valid_volumes: "{{ valid_volumes | combine({item.name: item.mount_path}) }}"
       with_items: "{{ hostvars['localhost']['volumes'] }}"
       when: inventory_hostname in item.host_access_policies
 
     - name: Parse volume, mount path and volume id
       ansible.builtin.set_fact:
-        devices: "{{ devices|combine( { valid_volumes[item.key]:item.value } ) }}"
+        devices: "{{ devices | combine({valid_volumes[item.key]: item.value}) }}"
       with_dict: "{{ hostvars['localhost']['map_volumes'] }}"
       when: item.key in valid_volumes.keys()
 
@@ -83,7 +83,7 @@
 
     - name: Obtain a list of volumes that fail to unmount
       ansible.builtin.set_fact:
-        failed_unmount: "{{ failed_unmount + [ item.item.key] }}"
+        failed_unmount: "{{ failed_unmount + [item.item.key] }}"
       when: item.failed
       with_items: "{{ unmount_report.results }}"
       delegate_facts: true
@@ -91,7 +91,7 @@
 
     - name: Get a list of IQN with unique elements
       ansible.builtin.set_fact:
-        iqn_list: "{{ iqn_list + [ item.value.iqn ] }}"
+        iqn_list: "{{ iqn_list + [item.value.iqn] }}"
       with_dict: "{{ devices }}"
       when: item.value.iqn not in iqn_list
 
@@ -132,7 +132,7 @@
 
     - name: Create IQN/Hostname dictionary
       ansible.builtin.set_fact:
-        iqn_data: "{{ iqn_data|default({}) + [ {'hostname':item, 'iqn':(hostvars[item]['iqn'].stdout)} ] }}"
+        iqn_data: "{{ iqn_data | default([]) + [{'hostname': item, 'iqn': (hostvars[item]['iqn'].stdout)}] }}"
       with_items:
         - "{{ groups['Initiators_Hosts'] }}"
 

--- a/ansible/simple/setup_infrastructure.yml
+++ b/ansible/simple/setup_infrastructure.yml
@@ -18,6 +18,7 @@
         state: present  # or absent
         name: az1
         display_name: "az1"
+        region: region1
 
     - name: Create new network interface group
       purestorage.fusion.fusion_nig:


### PR DESCRIPTION
**SUMMARY**
Fixed linter errors in playbooks and added `requirements.yml`. Tested manually.

**ADDITIONAL INFORMATION**
After PR merge, playbooks will be moved to [ansible-playbook-examples](https://github.com/PureStorage-OpenConnect/ansible-playbook-examples).